### PR TITLE
Drop of PHP 8.0 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,18 +12,20 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "php": "^8.0 || ^8.1 || ^8.2 || ^8.3",
+        "php": "^8.1 || ^8.2 || ^8.3",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^7.0",
         "psr/http-client": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "*",
-        "squizlabs/php_codesniffer": "3.*",
-        "symplify/easy-coding-standard": "9.3.20",
-        "symplify/config-transformer": "^9.3",
-        "phpstan/phpstan": "^0.12.89",
-        "symfony/var-dumper": "^5.3"
+        "squizlabs/php_codesniffer": "^3.10",
+        "symplify/easy-coding-standard": "^12.1",
+        "symplify/config-transformer": "^12.3",
+        "phpstan/phpstan": "^1.12",
+        "symfony/var-dumper": "^6.4",
+        "symplify/coding-standard": "^12.0",
+        "kubawerlos/php-cs-fixer-custom-fixers": "^3.22"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "phpstan/phpstan": "^1.12",
         "symfony/var-dumper": "^6.4",
         "symplify/coding-standard": "^12.0",
-        "kubawerlos/php-cs-fixer-custom-fixers": "^3.22"
+        "kubawerlos/php-cs-fixer-custom-fixers": "^3.22",
+        "rector/rector": "^1.2"
     },
     "autoload": {
         "psr-4": {

--- a/ecs.php
+++ b/ecs.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
+use PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\AssignmentInConditionSniff;
 use PhpCsFixerCustomFixers\Fixer\NoImportFromGlobalNamespaceFixer;
 use PhpCsFixerCustomFixers\Fixer\NoSuperfluousConcatenationFixer;
 use PhpCsFixerCustomFixers\Fixer\NoUselessCommentFixer;
-use PhpCsFixerCustomFixers\Fixer\OperatorLinebreakFixer;
 use PhpCsFixerCustomFixers\Fixer\PhpdocNoIncorrectVarAnnotationFixer;
 use PhpCsFixerCustomFixers\Fixer\SingleSpaceAfterStatementFixer;
 use PhpCsFixer\Fixer\CastNotation\ModernizeTypesCastingFixer;
@@ -14,65 +14,57 @@ use PhpCsFixer\Fixer\ClassNotation\SelfAccessorFixer;
 use PhpCsFixer\Fixer\FunctionNotation\MethodArgumentSpaceFixer;
 use PhpCsFixer\Fixer\FunctionNotation\NullableTypeDeclarationForDefaultNullValueFixer;
 use PhpCsFixer\Fixer\FunctionNotation\VoidReturnFixer;
+use PhpCsFixer\Fixer\Import\NoUnusedImportsFixer;
 use PhpCsFixer\Fixer\LanguageConstruct\ExplicitIndirectVariableFixer;
 use PhpCsFixer\Fixer\Operator\ConcatSpaceFixer;
 use PhpCsFixer\Fixer\PhpTag\BlankLineAfterOpeningTagFixer;
 use PhpCsFixer\Fixer\Phpdoc\GeneralPhpdocAnnotationRemoveFixer;
-use PhpCsFixer\Fixer\Phpdoc\NoSuperfluousPhpdocTagsFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocOrderFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocSummaryFixer;
 use PhpCsFixer\Fixer\ReturnNotation\NoUselessReturnFixer;
 use PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer;
 use PhpCsFixer\Fixer\StringNotation\ExplicitStringVariableFixer;
-use PhpCsFixer\Fixer\Whitespace\CompactNullableTypehintFixer;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use PhpCsFixer\Fixer\Whitespace\CompactNullableTypeDeclarationFixer;
+use Symplify\EasyCodingStandard\Config\ECSConfig;
 
-return static function (ContainerConfigurator $containerConfigurator): void {
-    $services = $containerConfigurator->services();
+return static function (ECSConfig $ecsConfig): void {
+    $ecsConfig->rule(ModernizeTypesCastingFixer::class);
+    $ecsConfig->ruleWithConfiguration(
+        ClassAttributesSeparationFixer::class,
+        ['elements' => ['property' => 'one', 'method' => 'one', 'const' => 'one']]
+    );
+    $ecsConfig->ruleWithConfiguration(
+        MethodArgumentSpaceFixer::class,
+        [['on_multiline' => 'ensure_fully_multiline']]
+    );
+    $ecsConfig->rule(NullableTypeDeclarationForDefaultNullValueFixer::class);
+    $ecsConfig->rule(VoidReturnFixer::class);
+    $ecsConfig->ruleWithConfiguration(
+        ConcatSpaceFixer::class,
+        ['spacing' => 'one']
+    );
+    $ecsConfig->ruleWithConfiguration(
+        GeneralPhpdocAnnotationRemoveFixer::class,
+        ['annotations' => ['copyright', 'category']]
+    );
+    $ecsConfig->rule(PhpdocOrderFixer::class);
+    $ecsConfig->rule(NoUselessReturnFixer::class);
+    $ecsConfig->rule(NoUnusedImportsFixer::class);
+    $ecsConfig->rule(DeclareStrictTypesFixer::class);
+    $ecsConfig->rule(CompactNullableTypeDeclarationFixer::class);
+    $ecsConfig->rule(NoImportFromGlobalNamespaceFixer::class);
+    $ecsConfig->rule(NoSuperfluousConcatenationFixer::class);
+    $ecsConfig->rule(NoUselessCommentFixer::class);
+    $ecsConfig->rule(PhpdocNoIncorrectVarAnnotationFixer::class);
+    $ecsConfig->rule(SingleSpaceAfterStatementFixer::class);
 
-    $services->set(ModernizeTypesCastingFixer::class);
-
-    $services->set(ClassAttributesSeparationFixer::class)
-        ->call('configure', [['elements' => ['property' => 'one', 'method' => 'one', 'const' => 'one']]]);
-
-    $services->set(MethodArgumentSpaceFixer::class)
-        ->call('configure', [['on_multiline' => 'ensure_fully_multiline']]);
-
-    $services->set(NullableTypeDeclarationForDefaultNullValueFixer::class);
-
-    $services->set(VoidReturnFixer::class);
-
-    $services->set(ConcatSpaceFixer::class)
-        ->call('configure', [['spacing' => 'one']]);
-
-    $services->set(GeneralPhpdocAnnotationRemoveFixer::class)
-        ->call('configure', [['annotations' => ['copyright', 'category']]]);
-
-//    $services->set(NoSuperfluousPhpdocTagsFixer::class);
-
-    $services->set(PhpdocOrderFixer::class);
-
-    $services->set(NoUselessReturnFixer::class);
-
-    $services->set(\PhpCsFixer\Fixer\Import\NoUnusedImportsFixer::class);
-
-    $services->set(DeclareStrictTypesFixer::class);
-
-    $services->set(CompactNullableTypehintFixer::class);
-
-    $services->set(NoImportFromGlobalNamespaceFixer::class);
-
-    $services->set(NoSuperfluousConcatenationFixer::class);
-
-    $services->set(NoUselessCommentFixer::class);
-
-    $services->set(OperatorLinebreakFixer::class);
-
-    $services->set(PhpdocNoIncorrectVarAnnotationFixer::class);
-
-    $services->set(SingleSpaceAfterStatementFixer::class);
-
-    $parameters = $containerConfigurator->parameters();
-
-    $parameters->set('skip', [SelfAccessorFixer::class => null, ExplicitIndirectVariableFixer::class => null, BlankLineAfterOpeningTagFixer::class => null, PhpdocSummaryFixer::class => null, ExplicitStringVariableFixer::class => null, 'PhpCsFixerCustomFixers\Fixer\NoUselessCommentFixer' => null, 'PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\AssignmentInConditionSniff' => null]);
+    $ecsConfig->skip([
+        SelfAccessorFixer::class,
+        ExplicitIndirectVariableFixer::class,
+        BlankLineAfterOpeningTagFixer::class,
+        PhpdocSummaryFixer::class,
+        ExplicitStringVariableFixer::class,
+        NoUselessCommentFixer::class,
+        AssignmentInConditionSniff::class,
+    ]);
 };

--- a/ecs.php
+++ b/ecs.php
@@ -35,7 +35,7 @@ return static function (ECSConfig $ecsConfig): void {
     );
     $ecsConfig->ruleWithConfiguration(
         MethodArgumentSpaceFixer::class,
-        [['on_multiline' => 'ensure_fully_multiline']]
+        ['on_multiline' => 'ensure_fully_multiline']
     );
     $ecsConfig->rule(NullableTypeDeclarationForDefaultNullValueFixer::class);
     $ecsConfig->rule(VoidReturnFixer::class);

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,8 +1,6 @@
 parameters:
     level: 8
     treatPhpDocTypesAsCertain: false
-    checkMissingIterableValueType: false
-    checkGenericClassInNonGenericObjectType: false
     inferPrivatePropertyTypeFromConstructor: true
     reportUnmatchedIgnoredErrors: true # Could be set to false if necessary during PHPStan update
     tmpDir: ./var/cache/phpstan
@@ -15,6 +13,10 @@ parameters:
     excludes_analyse:
 
     ignoreErrors:
+        -
+            identifier: missingType.iterableValue
+        -
+            identifier: missingType.generics
         -
             message: '#Unsafe usage of new static\(\)#'
             path: src/Data/Collection.php

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Set\ValueObject\LevelSetList;
+
+return RectorConfig::configure()
+    ->withSets([LevelSetList::UP_TO_PHP_81]);

--- a/src/Client/AdminAuthenticator.php
+++ b/src/Client/AdminAuthenticator.php
@@ -31,11 +31,9 @@ class AdminAuthenticator
 
     private array $config;
 
-    private GrantType $grantType;
-
     private string $endpoint;
 
-    public function __construct(GrantType $grantType, string $endpoint, array $config = [])
+    public function __construct(private GrantType $grantType, string $endpoint, array $config = [])
     {
         $this->config = array_merge([
             'sec_before_refresh' => 30,
@@ -43,8 +41,7 @@ class AdminAuthenticator
             'sec_before_attempt' => 1,
         ], $config);
 
-        $this->httpClient = $this->httpClient ?? $this->createHttpClient($this->config);
-        $this->grantType = $grantType;
+        $this->httpClient ??= $this->createHttpClient($this->config);
         $this->endpoint = $this->removeLastSlashes($endpoint);
     }
 

--- a/src/Client/Client.php
+++ b/src/Client/Client.php
@@ -24,11 +24,8 @@ class Client implements ClientInterface
 {
     use GuzzleClientTrait;
 
-    private GuzzleClientInterface $guzzleClient;
-
-    private function __construct(GuzzleClientInterface $guzzleClient)
+    private function __construct(private GuzzleClientInterface $guzzleClient)
     {
-        $this->guzzleClient = $guzzleClient;
     }
 
     public static function create(array $config = []): self

--- a/src/Client/GrantType/ClientCredentialsGrantType.php
+++ b/src/Client/GrantType/ClientCredentialsGrantType.php
@@ -6,11 +6,8 @@ namespace Vin\ShopwareSdk\Client\GrantType;
 
 class ClientCredentialsGrantType extends GrantType
 {
-    public string $clientSecret;
-
-    public function __construct(string $clientId, string $clientSecret)
+    public function __construct(string $clientId, public string $clientSecret)
     {
         parent::__construct(self::CLIENT_CREDENTIALS, $clientId);
-        $this->clientSecret = $clientSecret;
     }
 }

--- a/src/Client/GrantType/GrantType.php
+++ b/src/Client/GrantType/GrantType.php
@@ -18,15 +18,12 @@ abstract class GrantType
 
     public string $grantType;
 
-    public string $clientId;
-
-    public function __construct(string $grantType, string $clientId)
+    public function __construct(string $grantType, public string $clientId)
     {
         if (!\in_array($grantType, self::ALLOWED_GRANTS)) {
             throw new \InvalidArgumentException('Grant type ' . $grantType . ' is not supported', 400);
         }
         $this->grantType = $grantType;
-        $this->clientId = $clientId;
     }
 
     public static function createFromConfig(array $config): GrantType
@@ -37,15 +34,11 @@ abstract class GrantType
 
         $grantType = $config['grant_type'];
 
-        switch ($grantType) {
-            case self::REFRESH_TOKEN:
-                return new RefreshTokenGrantType($config['refresh_token']);
-            case self::CLIENT_CREDENTIALS:
-                return new ClientCredentialsGrantType($config['client_id'], $config['client_secret']);
-            case self::PASSWORD:
-                return new PasswordGrantType($config['username'], $config['password'], $config['scopes'] ?? 'write');
-            default:
-                throw new \InvalidArgumentException('Grant type ' . $grantType . ' is not supported', 400);
-        }
+        return match ($grantType) {
+            self::REFRESH_TOKEN => new RefreshTokenGrantType($config['refresh_token']),
+            self::CLIENT_CREDENTIALS => new ClientCredentialsGrantType($config['client_id'], $config['client_secret']),
+            self::PASSWORD => new PasswordGrantType($config['username'], $config['password'], $config['scopes'] ?? 'write'),
+            default => throw new \InvalidArgumentException('Grant type ' . $grantType . ' is not supported', 400),
+        };
     }
 }

--- a/src/Client/GrantType/PasswordGrantType.php
+++ b/src/Client/GrantType/PasswordGrantType.php
@@ -6,17 +6,8 @@ namespace Vin\ShopwareSdk\Client\GrantType;
 
 class PasswordGrantType extends GrantType
 {
-    public string $username;
-
-    public string $password;
-
-    public string $scopes;
-
-    public function __construct(string $username, string $password, string $scopes = 'write')
+    public function __construct(public string $username, public string $password, public string $scopes = 'write')
     {
         parent::__construct(self::PASSWORD, self::ADMINISTRATION_CLIENT_ID);
-        $this->username = $username;
-        $this->password = $password;
-        $this->scopes = $scopes;
     }
 }

--- a/src/Client/GrantType/RefreshTokenGrantType.php
+++ b/src/Client/GrantType/RefreshTokenGrantType.php
@@ -6,15 +6,12 @@ namespace Vin\ShopwareSdk\Client\GrantType;
 
 class RefreshTokenGrantType extends GrantType
 {
-    public string $refreshToken;
-
     public string $password;
 
     public string $scopes;
 
-    public function __construct(string $refreshToken)
+    public function __construct(public string $refreshToken)
     {
         parent::__construct(self::REFRESH_TOKEN, self::ADMINISTRATION_CLIENT_ID);
-        $this->refreshToken = $refreshToken;
     }
 }

--- a/src/Data/AccessToken.php
+++ b/src/Data/AccessToken.php
@@ -4,20 +4,8 @@ namespace Vin\ShopwareSdk\Data;
 
 class AccessToken
 {
-    public string $accessToken;
-
-    public int $expiresIn;
-
-    public string $tokenType;
-
-    public ?string $refreshToken;
-
-    public function __construct(string $accessToken, int $expiresIn = 600, string $tokenType = 'Bearer', ?string $refreshToken = null)
+    public function __construct(public string $accessToken, public int $expiresIn = 600, public string $tokenType = 'Bearer', public ?string $refreshToken = null)
     {
-        $this->accessToken = $accessToken;
-        $this->expiresIn = $expiresIn;
-        $this->tokenType = $tokenType;
-        $this->refreshToken = $refreshToken;
     }
 
     public function isExpired() : bool

--- a/src/Data/Aggregation/AverageAggregation.php
+++ b/src/Data/Aggregation/AverageAggregation.php
@@ -6,14 +6,8 @@ namespace Vin\ShopwareSdk\Data\Aggregation;
 
 class AverageAggregation extends Aggregation
 {
-    public string $name;
-
-    public string $field;
-
-    public function __construct(string $name, string $field)
+    public function __construct(public string $name, public string $field)
     {
-        $this->name = $name;
-        $this->field = $field;
     }
 
     public function parse(): array

--- a/src/Data/Aggregation/CountAggregation.php
+++ b/src/Data/Aggregation/CountAggregation.php
@@ -6,14 +6,8 @@ namespace Vin\ShopwareSdk\Data\Aggregation;
 
 class CountAggregation extends Aggregation
 {
-    public string $name;
-
-    public string $field;
-
-    public function __construct(string $name, string $field)
+    public function __construct(public string $name, public string $field)
     {
-        $this->name = $name;
-        $this->field = $field;
     }
 
     public function parse(): array

--- a/src/Data/Aggregation/FilterAggregation.php
+++ b/src/Data/Aggregation/FilterAggregation.php
@@ -8,20 +8,15 @@ use Vin\ShopwareSdk\Data\Filter\Filter;
 
 class FilterAggregation extends Aggregation
 {
-    public string $name;
-
-    /**
-     * @var Filter[]
-     */
-    public array $filter;
-
-    public Aggregation $aggregation;
-
-    public function __construct(string $name, array $filter, Aggregation $aggregation)
+    public function __construct(
+        public string $name,
+        /**
+         * @var Filter[]
+         */
+        public array $filter,
+        public Aggregation $aggregation
+    )
     {
-        $this->name = $name;
-        $this->filter = $filter;
-        $this->aggregation = $aggregation;
     }
 
     public function parse(): array
@@ -29,9 +24,7 @@ class FilterAggregation extends Aggregation
         return [
             'type' => self::TYPE_FILTER,
             'name' => $this->name,
-            'filter' => array_map(function (Filter $filter) {
-                return $filter->parse();
-            }, $this->filter),
+            'filter' => array_map(fn(Filter $filter) => $filter->parse(), $this->filter),
             'aggregation' => $this->aggregation->parse()
         ];
     }

--- a/src/Data/Aggregation/HistogramAggregation.php
+++ b/src/Data/Aggregation/HistogramAggregation.php
@@ -22,33 +22,13 @@ class HistogramAggregation extends Aggregation
 
     public const PER_YEAR = 'year';
 
-    public string $name;
-
     /**
      * @var Filter[]
      */
     public array $filter;
 
-    public ?Aggregation $aggregation = null;
-
-    public string $field;
-
-    public string $interval;
-
-    public ?string $format;
-
-    public function __construct(
-        string $name,
-        string $field,
-        string $interval,
-        ?string $format = null,
-        ?Aggregation $aggregation = null
-    ) {
-        $this->name = $name;
-        $this->aggregation = $aggregation;
-        $this->field = $field;
-        $this->interval = $interval;
-        $this->format = $format;
+    public function __construct(public string $name, public string $field, public string $interval, public ?string $format = null, public ?Aggregation $aggregation = null)
+    {
     }
 
     public function parse(): array

--- a/src/Data/Aggregation/MaxAggregation.php
+++ b/src/Data/Aggregation/MaxAggregation.php
@@ -6,14 +6,8 @@ namespace Vin\ShopwareSdk\Data\Aggregation;
 
 class MaxAggregation extends Aggregation
 {
-    public string $name;
-
-    public string $field;
-
-    public function __construct(string $name, string $field)
+    public function __construct(public string $name, public string $field)
     {
-        $this->name = $name;
-        $this->field = $field;
     }
 
     public function parse(): array

--- a/src/Data/Aggregation/MinAggregation.php
+++ b/src/Data/Aggregation/MinAggregation.php
@@ -6,14 +6,8 @@ namespace Vin\ShopwareSdk\Data\Aggregation;
 
 class MinAggregation extends Aggregation
 {
-    public string $name;
-
-    public string $field;
-
-    public function __construct(string $name, string $field)
+    public function __construct(public string $name, public string $field)
     {
-        $this->name = $name;
-        $this->field = $field;
     }
 
     public function parse(): array

--- a/src/Data/Aggregation/StatsAggregation.php
+++ b/src/Data/Aggregation/StatsAggregation.php
@@ -6,14 +6,8 @@ namespace Vin\ShopwareSdk\Data\Aggregation;
 
 class StatsAggregation extends Aggregation
 {
-    public string $name;
-
-    public string $field;
-
-    public function __construct(string $name, string $field)
+    public function __construct(public string $name, public string $field)
     {
-        $this->name = $name;
-        $this->field = $field;
     }
 
     public function parse(): array

--- a/src/Data/Aggregation/SumAggregation.php
+++ b/src/Data/Aggregation/SumAggregation.php
@@ -6,14 +6,8 @@ namespace Vin\ShopwareSdk\Data\Aggregation;
 
 class SumAggregation extends Aggregation
 {
-    public string $name;
-
-    public string $field;
-
-    public function __construct(string $name, string $field)
+    public function __construct(public string $name, public string $field)
     {
-        $this->name = $name;
-        $this->field = $field;
     }
 
     public function parse(): array

--- a/src/Data/Aggregation/TermsAggregation.php
+++ b/src/Data/Aggregation/TermsAggregation.php
@@ -9,33 +9,13 @@ use Vin\ShopwareSdk\Data\Filter\Filter;
 
 class TermsAggregation extends Aggregation
 {
-    public string $name;
-
     /**
      * @var Filter[]
      */
     public array $filter;
 
-    public ?Aggregation $aggregation = null;
-
-    public string $field;
-
-    public ?int $limit;
-
-    public ?FieldSorting $sort = null;
-
-    public function __construct(
-        string $name,
-        string $field,
-        ?int $limit = null,
-        ?FieldSorting $sort = null,
-        ?Aggregation $aggregation = null
-    ) {
-        $this->name = $name;
-        $this->aggregation = $aggregation;
-        $this->field = $field;
-        $this->limit = $limit;
-        $this->sort = $sort;
+    public function __construct(public string $name, public string $field, public ?int $limit = null, public ?FieldSorting $sort = null, public ?Aggregation $aggregation = null)
+    {
     }
 
     public function parse(): array

--- a/src/Data/Association.php
+++ b/src/Data/Association.php
@@ -6,13 +6,7 @@ namespace Vin\ShopwareSdk\Data;
 
 class Association
 {
-    public string $association;
-
-    public Criteria $criteria;
-
-    public function __construct(string $association, Criteria $criteria)
+    public function __construct(public string $association, public Criteria $criteria)
     {
-        $this->association = $association;
-        $this->criteria = $criteria;
     }
 }

--- a/src/Data/Collection.php
+++ b/src/Data/Collection.php
@@ -106,9 +106,7 @@ abstract class Collection extends Struct implements \IteratorAggregate, \Countab
      */
     public function filterInstance(string $class)
     {
-        return $this->filter(static function ($item) use ($class) {
-            return $item instanceof $class;
-        });
+        return $this->filter(static fn($item) => $item instanceof $class);
     }
 
     /**
@@ -134,9 +132,7 @@ abstract class Collection extends Struct implements \IteratorAggregate, \Countab
 
     public function jsonSerialize(): array
     {
-        return array_values(array_map(function (Struct $element) {
-            return $element->jsonSerialize();
-        }, $this->elements));
+        return array_values(array_map(fn(Struct $element) => $element->jsonSerialize(), $this->elements));
     }
 
     public function first(): ?Struct
@@ -178,10 +174,7 @@ abstract class Collection extends Struct implements \IteratorAggregate, \Countab
         return new static($elements);
     }
 
-    /**
-     * @param mixed $element
-     */
-    protected function validateType($element): void
+    protected function validateType(mixed $element): void
     {
         $expectedClass = $this->getExpectedClass();
         if ($expectedClass === null) {
@@ -189,7 +182,7 @@ abstract class Collection extends Struct implements \IteratorAggregate, \Countab
         }
 
         if (!$element instanceof $expectedClass) {
-            $elementClass = \get_class($element);
+            $elementClass = $element::class;
 
             throw new \InvalidArgumentException(
                 sprintf('Expected collection element of type %s got %s', $expectedClass, $elementClass)

--- a/src/Data/Context.php
+++ b/src/Data/Context.php
@@ -6,39 +6,18 @@ class Context
 {
     use EndPointTrait;
 
-    public string $languageId = Defaults::LANGUAGE_SYSTEM;
-
-    public string $currencyId = Defaults::CURRENCY;
-
-    public string $versionId = Defaults::LIVE_VERSION;
-
-    public bool $compatibility = true;
-
-    public bool $inheritance = true;
-
-    public AccessToken $accessToken;
-
     public string $apiEndpoint;
-    
-    public array $additionalHeaders;
 
     public function __construct(
         string $apiEndpoint,
-        AccessToken $accessToken,
-        string $languageId = Defaults::LANGUAGE_SYSTEM,
-        string $currencyId = Defaults::CURRENCY,
-        string $versionId = Defaults::LIVE_VERSION,
-        bool $compatibility = true,
-        bool $inheritance = true,
-        array $additionalHeaders = []
+        public AccessToken $accessToken,
+        public string $languageId = Defaults::LANGUAGE_SYSTEM,
+        public string $currencyId = Defaults::CURRENCY,
+        public string $versionId = Defaults::LIVE_VERSION,
+        public bool $compatibility = true,
+        public bool $inheritance = true,
+        public array $additionalHeaders = []
     ) {
-        $this->languageId = $languageId;
-        $this->currencyId = $currencyId;
-        $this->versionId = $versionId;
-        $this->compatibility = $compatibility;
-        $this->inheritance = $inheritance;
-        $this->accessToken = $accessToken;
         $this->apiEndpoint = $this->removeLastSlashes($apiEndpoint);
-        $this->additionalHeaders = $additionalHeaders;
     }
 }

--- a/src/Data/Criteria.php
+++ b/src/Data/Criteria.php
@@ -36,20 +36,6 @@ class Criteria implements ParseAware
     public const TOTAL_COUNT_MODE_NEXT_PAGES = 2;
 
     /**
-     * page and limit should be mixed to allow null also
-     * this would prevent from generating pagination problems
-     * 
-     * @var mixed
-     */
-    private $page;
-
-    /**
-     * see above
-     * @var mixed
-     */
-    private $limit;
-
-    /**
      * Don't use term parameters together with query parameters.
      */
     private ?string $term = null;
@@ -100,10 +86,18 @@ class Criteria implements ParseAware
      * @param $page
      * @param $limit
      */
-    public function __construct($page = null, $limit = null)
+    public function __construct(
+        /**
+         * page and limit should be mixed to allow null also
+         * this would prevent from generating pagination problems
+         */
+        private mixed $page = null,
+        /**
+         * see above
+         */
+        private mixed $limit = null
+    )
     {
-        $this->page = $page;
-        $this->limit = $limit;
     }
 
     public function addFilter(Filter ...$filters): self
@@ -298,10 +292,7 @@ class Criteria implements ParseAware
         return new RangeFilter($field, $range);
     }
 
-    /**
-     * @param mixed $value
-     */
-    public static function equals(string $field, $value): EqualsFilter
+    public static function equals(string $field, mixed $value): EqualsFilter
     {
         return new EqualsFilter($field, $value);
     }

--- a/src/Data/EndPointTrait.php
+++ b/src/Data/EndPointTrait.php
@@ -6,7 +6,7 @@ trait EndPointTrait
 {
     private function removeLastSlashes(string $endpoint): string
     {
-        while (substr($endpoint, -1) === '/') {
+        while (str_ends_with($endpoint, '/')) {
             $endpoint = rtrim($endpoint, '/');
         }
 

--- a/src/Data/Entity/Entity.php
+++ b/src/Data/Entity/Entity.php
@@ -11,17 +11,17 @@ class Entity extends Struct
 
     public string $_uniqueIdentifier;
 
-    public ?string $versionId;
+    public ?string $versionId = null;
 
     protected array $translated = [];
 
-    public ?\DateTimeInterface $createdAt;
+    public ?\DateTimeInterface $createdAt = null;
 
-    public ?\DateTimeInterface $updatedAt;
+    public ?\DateTimeInterface $updatedAt = null;
 
-    private ?string $_entityName;
+    private ?string $_entityName = null;
 
-    public ?string $apiAlias;
+    public ?string $apiAlias = null;
 
     private const NON_STRUCT_PROPERTY_TYPES = ['string', 'array', 'object', 'resource', 'bool', 'int', 'float', 'double'];
 
@@ -32,10 +32,7 @@ class Entity extends Struct
         return property_exists($this, $property);
     }
 
-    /**
-     * @param mixed $value
-     */
-    public function setProperty(string $property, $value): void
+    public function setProperty(string $property, mixed $value): void
     {
         if (!$this->has($property)) {
             $this->$property = $value;
@@ -81,9 +78,7 @@ class Entity extends Struct
                 $this->$property = self::createFromArray($typeName, $value);
                 break;
             case $dummyType instanceof EntityCollection:
-                $value = array_map(function (array $item) use ($dummyType) {
-                    return self::createFromArray($dummyType->getExpectedClass(), $item);
-                }, $value);
+                $value = array_map(fn(array $item) => self::createFromArray($dummyType->getExpectedClass(), $item), $value);
                 $this->$property = new $dummyType($value);
                 break;
             case $reflectionClass->implementsInterface(\DateTimeInterface::class):
@@ -139,10 +134,7 @@ class Entity extends Struct
         $this->translated = $translated;
     }
 
-    /**
-     * @param mixed $value
-     */
-    public function addTranslated(string $key, $value): void
+    public function addTranslated(string $key, mixed $value): void
     {
         $this->translated[$key] = $value;
     }
@@ -170,7 +162,7 @@ class Entity extends Struct
 
             try {
                 $this->setProperty($key, $value);
-            } catch (\Error | \Exception $error) {
+            } catch (\Error | \Exception) {
                 // nth
             }
         }

--- a/src/Data/Entity/EntityCollection.php
+++ b/src/Data/Entity/EntityCollection.php
@@ -21,27 +21,17 @@ class EntityCollection extends Collection
 {
     public function getIds(): array
     {
-        return $this->fmap(static function (Entity $entity) {
-            return $entity->id;
-        });
+        return $this->fmap(static fn(Entity $entity) => $entity->id);
     }
 
-    /**
-     * @param mixed $value
-     */
-    public function filterByProperty(string $property, $value): self
+    public function filterByProperty(string $property, mixed $value): self
     {
         return $this->filter(
-            static function (Entity $struct) use ($property, $value) {
-                return $struct->$property === $value;
-            }
+            static fn(Entity $struct) => $struct->$property === $value
         );
     }
 
-    /**
-     * @param mixed $value
-     */
-    public function filterAndReduceByProperty(string $property, $value): self
+    public function filterAndReduceByProperty(string $property, mixed $value): self
     {
         $filtered = [];
 
@@ -82,9 +72,7 @@ class EntityCollection extends Collection
 
     public function filterInstance(string $class): self
     {
-        return $this->filter(static function ($item) use ($class) {
-            return $item instanceof $class;
-        });
+        return $this->filter(static fn($item) => $item instanceof $class);
     }
 
     public function getExpectedClass(): string

--- a/src/Data/FieldSorting.php
+++ b/src/Data/FieldSorting.php
@@ -8,20 +8,8 @@ class FieldSorting implements ParseAware
 
     public const DESCENDING = 'DESC';
 
-    public string $field;
-
-    public string $order;
-
-    public bool $naturalSorting;
-
-    public function __construct(
-        string $field,
-        string $order = self::ASCENDING,
-        bool $naturalSorting = false
-    ) {
-        $this->field = $field;
-        $this->order = $order;
-        $this->naturalSorting = $naturalSorting;
+    public function __construct(public string $field, public string $order = self::ASCENDING, public bool $naturalSorting = false)
+    {
     }
 
     public function parse(): array

--- a/src/Data/Filter/ContainsFilter.php
+++ b/src/Data/Filter/ContainsFilter.php
@@ -6,14 +6,8 @@ namespace Vin\ShopwareSdk\Data\Filter;
 
 class ContainsFilter extends Filter
 {
-    private string $field;
-
-    private string $value;
-
-    public function __construct(string $field, string $value)
+    public function __construct(private readonly string $field, private readonly string $value)
     {
-        $this->field = $field;
-        $this->value = $value;
     }
 
     public function parse(): array

--- a/src/Data/Filter/EqualsAnyFilter.php
+++ b/src/Data/Filter/EqualsAnyFilter.php
@@ -6,14 +6,8 @@ namespace Vin\ShopwareSdk\Data\Filter;
 
 class EqualsAnyFilter extends Filter
 {
-    private string $field;
-
-    private array $value;
-
-    public function __construct(string $field, array $value)
+    public function __construct(private readonly string $field, private readonly array $value)
     {
-        $this->field = $field;
-        $this->value = $value;
     }
 
     public function parse(): array

--- a/src/Data/Filter/EqualsFilter.php
+++ b/src/Data/Filter/EqualsFilter.php
@@ -6,20 +6,8 @@ namespace Vin\ShopwareSdk\Data\Filter;
 
 class EqualsFilter extends Filter
 {
-    private string $field;
-
-    /**
-     * @var mixed
-     */
-    private $value;
-
-    /**
-     * @param mixed $value
-     */
-    public function __construct(string $field, $value)
+    public function __construct(private readonly string $field, private readonly mixed $value)
     {
-        $this->field = $field;
-        $this->value = $value;
     }
 
     public function parse(): array

--- a/src/Data/Filter/MultiFilter.php
+++ b/src/Data/Filter/MultiFilter.php
@@ -12,17 +12,14 @@ class MultiFilter extends Filter
 
     public const OP_XOR = 'xor';
 
-    public string $operator;
-
-    /**
-     * @var Filter[]
-     */
-    public array $queries;
-
-    public function __construct(string $operator, array $queries)
+    public function __construct(
+        public string $operator,
+        /**
+         * @var Filter[]
+         */
+        public array $queries
+    )
     {
-        $this->operator = $operator;
-        $this->queries = $queries;
     }
 
     public function parse(): array
@@ -30,9 +27,7 @@ class MultiFilter extends Filter
         return [
             'type' => self::TYPE_MULTI,
             'operator' => $this->operator,
-            'queries' => array_map(function (Filter $filter) {
-                return $filter->parse();
-            }, $this->queries)
+            'queries' => array_map(fn(Filter $filter) => $filter->parse(), $this->queries)
         ];
     }
 }

--- a/src/Data/Filter/NotFilter.php
+++ b/src/Data/Filter/NotFilter.php
@@ -12,17 +12,14 @@ class NotFilter extends Filter
 
     public const OP_XOR = 'xor';
 
-    public string $operator;
-
-    /**
-     * @var Filter[]
-     */
-    public array $queries;
-
-    public function __construct(string $operator, array $queries)
+    public function __construct(
+        public string $operator,
+        /**
+         * @var Filter[]
+         */
+        public array $queries
+    )
     {
-        $this->operator = $operator;
-        $this->queries = $queries;
     }
 
     public function parse(): array
@@ -30,9 +27,7 @@ class NotFilter extends Filter
         return [
             'type' => self::TYPE_NOT,
             'operator' => $this->operator,
-            'queries' => array_map(function (Filter $filter) {
-                return $filter->parse();
-            }, $this->queries)
+            'queries' => array_map(fn(Filter $filter) => $filter->parse(), $this->queries)
         ];
     }
 }

--- a/src/Data/Filter/PrefixFilter.php
+++ b/src/Data/Filter/PrefixFilter.php
@@ -6,14 +6,8 @@ namespace Vin\ShopwareSdk\Data\Filter;
 
 class PrefixFilter extends Filter
 {
-    private string $field;
-
-    private string $value;
-
-    public function __construct(string $field, string $value)
+    public function __construct(private readonly string $field, private readonly string $value)
     {
-        $this->field = $field;
-        $this->value = $value;
     }
 
     public function parse(): array

--- a/src/Data/Filter/RangeFilter.php
+++ b/src/Data/Filter/RangeFilter.php
@@ -26,14 +26,8 @@ class RangeFilter extends Filter
 
     public const GT = 'gt';
 
-    private string $field;
-
-    private array $range;
-
-    public function __construct(string $field, array $range)
+    public function __construct(private readonly string $field, private readonly array $range)
     {
-        $this->field = $field;
-        $this->range = $range;
     }
 
     public function parse(): array

--- a/src/Data/Filter/SuffixFilter.php
+++ b/src/Data/Filter/SuffixFilter.php
@@ -6,14 +6,8 @@ namespace Vin\ShopwareSdk\Data\Filter;
 
 class SuffixFilter extends Filter
 {
-    private string $field;
-
-    private string $value;
-
-    public function __construct(string $field, string $value)
+    public function __construct(private readonly string $field, private readonly string $value)
     {
-        $this->field = $field;
-        $this->value = $value;
     }
 
     public function parse(): array

--- a/src/Data/Mail/Mail.php
+++ b/src/Data/Mail/Mail.php
@@ -6,60 +6,8 @@ use Vin\ShopwareSdk\Data\Struct;
 
 class Mail extends Struct
 {
-    protected string $salesChannelId;
-
-    protected string $subject;
-
-    protected string $contentHtml;
-
-    protected string $contentPlain;
-
-    protected string $senderName;
-
-    protected array $recipients;
-
-    protected array $mediaIds;
-
-    protected array $binAttachments;
-
-    protected array $recipientsBcc;
-
-    protected array $recipientsCc;
-
-    protected array $replyTo;
-
-    protected ?string $senderEmail;
-
-    protected ?string $returnPath;
-
-    public function __construct(
-        string $salesChannelId,
-        string $subject,
-        string $contentHtml,
-        string $contentPlain,
-        string $senderName,
-        array $recipients = [],
-        array $mediaIds = [],
-        array $binAttachments = [],
-        array $recipientsBcc = [],
-        array $recipientsCc = [],
-        array $replyTo = [],
-        ?string $senderEmail = null,
-        ?string $returnPath = null
-    ) {
-        $this->salesChannelId = $salesChannelId;
-        $this->subject = $subject;
-        $this->contentHtml = $contentHtml;
-        $this->contentPlain = $contentPlain;
-        $this->senderName = $senderName;
-        $this->recipients = $recipients;
-        $this->mediaIds = $mediaIds;
-        $this->binAttachments = $binAttachments;
-        $this->recipientsBcc = $recipientsBcc;
-        $this->recipientsCc = $recipientsCc;
-        $this->replyTo = $replyTo;
-        $this->senderEmail = $senderEmail;
-        $this->returnPath = $returnPath;
+    public function __construct(protected string $salesChannelId, protected string $subject, protected string $contentHtml, protected string $contentPlain, protected string $senderName, protected array $recipients = [], protected array $mediaIds = [], protected array $binAttachments = [], protected array $recipientsBcc = [], protected array $recipientsCc = [], protected array $replyTo = [], protected ?string $senderEmail = null, protected ?string $returnPath = null)
+    {
     }
 
     public function getSalesChannelId(): string

--- a/src/Data/Schema/Flag.php
+++ b/src/Data/Schema/Flag.php
@@ -6,19 +6,7 @@ use Vin\ShopwareSdk\Data\Struct;
 
 class Flag extends Struct
 {
-    public string $flag;
-
-    /**
-     * @var mixed
-     */
-    public $value;
-
-    /**
-     * @param mixed $value
-     */
-    public function __construct(string $flag, $value)
+    public function __construct(public string $flag, public mixed $value)
     {
-        $this->flag = $flag;
-        $this->value = $value;
     }
 }

--- a/src/Data/Schema/Property.php
+++ b/src/Data/Schema/Property.php
@@ -10,10 +10,6 @@ class Property extends Struct
 
     private const JSON_TYPES = ['json_list', 'json_object'];
 
-    public string $type;
-
-    public FlagCollection $flags;
-
     public ?string $relation;
 
     public ?string $reference;
@@ -30,16 +26,12 @@ class Property extends Struct
 
     public ?array $properties;
 
-    public string $name;
-
     public function __construct(
-        string $name,
-        string $type,
-        FlagCollection $flags,
+        public string $name,
+        public string $type,
+        public FlagCollection $flags,
         array $properties = []
     ) {
-        $this->type = $type;
-        $this->flags = $flags;
         $this->relation = $properties['relation'] ?? null;
         $this->local = $properties['local'] ?? null;
         $this->localField = $properties['localField'] ?? null;
@@ -48,7 +40,6 @@ class Property extends Struct
         $this->entity = $properties['entity'] ?? null;
         $this->mapping = $properties['mapping'] ?? null;
         $this->properties = $properties['properties'] ?? null;
-        $this->name = $name;
     }
 
     public function isScalarField(): bool

--- a/src/Data/Schema/Schema.php
+++ b/src/Data/Schema/Schema.php
@@ -6,14 +6,8 @@ use Vin\ShopwareSdk\Data\Struct;
 
 class Schema extends Struct
 {
-    public string $entity;
-
-    public PropertyCollection $properties;
-
-    public function __construct(string $entity, PropertyCollection $properties)
+    public function __construct(public string $entity, public PropertyCollection $properties)
     {
-        $this->entity = $entity;
-        $this->properties = $properties;
     }
 
     public static function createFromRaw(string $entity, array $properties): self

--- a/src/Data/ScoreQuery/ScoreQuery.php
+++ b/src/Data/ScoreQuery/ScoreQuery.php
@@ -6,17 +6,8 @@ use Vin\ShopwareSdk\Data\Filter\Filter;
 
 class ScoreQuery extends Filter
 {
-    protected float $score;
-
-    protected Filter $query;
-
-    protected ?string $scoreField;
-
-    public function __construct(Filter $query, float $score, ?string $scoreField = null)
+    public function __construct(protected Filter $query, protected float $score, protected ?string $scoreField = null)
     {
-        $this->score = $score;
-        $this->query = $query;
-        $this->scoreField = $scoreField;
     }
 
     public function getScore(): float

--- a/src/Data/Struct.php
+++ b/src/Data/Struct.php
@@ -91,7 +91,7 @@ class Struct
     {
         $extension = $this->getExtension($name);
 
-        return $extension !== null && \get_class($extension) === $type;
+        return $extension !== null && $extension::class === $type;
     }
 
     public function getExtensions(): array

--- a/src/Data/Webhook/App.php
+++ b/src/Data/Webhook/App.php
@@ -6,14 +6,8 @@ use Vin\ShopwareSdk\Data\Struct;
 
 class App extends Struct
 {
-    protected string $appSecret;
-
-    protected string $appName;
-
-    public function __construct(string $appName, string $appSecret)
+    public function __construct(protected string $appName, protected string $appSecret)
     {
-        $this->appSecret = $appSecret;
-        $this->appName = $appName;
     }
 
     public function getAppName(): string

--- a/src/Data/Webhook/AppAction/ActionData.php
+++ b/src/Data/Webhook/AppAction/ActionData.php
@@ -6,17 +6,8 @@ use Vin\ShopwareSdk\Data\Struct;
 
 class ActionData extends Struct
 {
-    protected array $ids;
-
-    protected string $entity;
-
-    protected string $action;
-
-    public function __construct(array $ids, string $entity, string $action)
+    public function __construct(protected array $ids, protected string $entity, protected string $action)
     {
-        $this->ids = $ids;
-        $this->entity = $entity;
-        $this->action = $action;
     }
 
     public function getAction(): string

--- a/src/Data/Webhook/AppAction/ActionMeta.php
+++ b/src/Data/Webhook/AppAction/ActionMeta.php
@@ -6,17 +6,8 @@ use Vin\ShopwareSdk\Data\Struct;
 
 class ActionMeta extends Struct
 {
-    protected int $timestamp;
-
-    protected string $reference;
-
-    protected string $language;
-
-    public function __construct(int $timestamp, string $reference, string $language)
+    public function __construct(protected int $timestamp, protected string $reference, protected string $language)
     {
-        $this->timestamp = $timestamp;
-        $this->reference = $reference;
-        $this->language = $language;
     }
 
     public function getTimestamp(): int

--- a/src/Data/Webhook/AppAction/AppAction.php
+++ b/src/Data/Webhook/AppAction/AppAction.php
@@ -7,23 +7,11 @@ use Vin\ShopwareSdk\Data\Webhook\Source;
 
 class AppAction extends Struct
 {
-    protected ?Source $source;
-
-    protected ?ActionData $data;
-
-    protected ?ActionMeta $meta;
-
-    protected array $headers;
-
     /**
      * Create the event from Event::createFromPayload.
      */
-    private function __construct(?Source $source, ?ActionData $data, ?ActionMeta $meta, array $headers)
+    private function __construct(protected ?Source $source, protected ?ActionData $data, protected ?ActionMeta $meta, protected array $headers)
     {
-        $this->source = $source;
-        $this->data = $data;
-        $this->meta = $meta;
-        $this->headers = $headers;
     }
     
     public function getSource(): ?Source

--- a/src/Data/Webhook/Event/Event.php
+++ b/src/Data/Webhook/Event/Event.php
@@ -7,23 +7,11 @@ use Vin\ShopwareSdk\Data\Webhook\Source;
 
 class Event extends Struct
 {
-    protected ?Source $source;
-
-    protected ?EventData $data;
-
-    protected int $timestamp;
-
-    protected array $headers;
-
     /**
      * Create the event from Event::createFromPayload.
      */
-    private function __construct(?Source $source, ?EventData $data, int $timestamp, array $headers)
+    private function __construct(protected ?Source $source, protected ?EventData $data, protected int $timestamp, protected array $headers)
     {
-        $this->source = $source;
-        $this->data = $data;
-        $this->timestamp = $timestamp;
-        $this->headers = $headers;
     }
 
     public function getSource(): ?Source

--- a/src/Data/Webhook/Event/EventData.php
+++ b/src/Data/Webhook/Event/EventData.php
@@ -6,14 +6,8 @@ use Vin\ShopwareSdk\Data\Struct;
 
 class EventData extends Struct
 {
-    protected string $event;
-
-    protected array $payload;
-
-    public function __construct(string $event, array $payload)
+    public function __construct(protected string $event, protected array $payload)
     {
-        $this->event = $event;
-        $this->payload = $payload;
     }
 
     public function getEvent(): string

--- a/src/Data/Webhook/Shop.php
+++ b/src/Data/Webhook/Shop.php
@@ -7,16 +7,10 @@ use Vin\ShopwareSdk\Data\Uuid\Uuid;
 
 class Shop extends Struct
 {
-    protected string $shopId;
-
-    protected string $shopUrl;
-
     protected string $shopSecret;
 
-    public function __construct(string $shopId, string $shopUrl, ?string $shopSecret = null)
+    public function __construct(protected string $shopId, protected string $shopUrl, ?string $shopSecret = null)
     {
-        $this->shopId = $shopId;
-        $this->shopUrl = $shopUrl;
         $this->shopSecret = $shopSecret ?? Uuid::randomHex();
     }
 

--- a/src/Data/Webhook/ShopRegistrationResult.php
+++ b/src/Data/Webhook/ShopRegistrationResult.php
@@ -6,14 +6,8 @@ use Vin\ShopwareSdk\Data\Struct;
 
 class ShopRegistrationResult extends Struct
 {
-    protected string $proof;
-
-    protected Shop $shop;
-
-    public function __construct(string $proof, Shop $shop)
+    public function __construct(protected string $proof, protected Shop $shop)
     {
-        $this->proof = $proof;
-        $this->shop = $shop;
     }
 
     public function getProof(): string

--- a/src/Data/Webhook/Source.php
+++ b/src/Data/Webhook/Source.php
@@ -6,20 +6,11 @@ use Vin\ShopwareSdk\Data\Struct;
 
 class Source extends Struct
 {
-    private string $shopUrl;
-
-    private string $shopId;
-
-    private string $appVersion;
-
     /**
      * Create the event from Event::createFromPayload.
      */
-    public function __construct(string $shopUrl, string $shopId, string $appVersion)
+    public function __construct(private readonly string $shopUrl, private readonly string $shopId, private readonly string $appVersion)
     {
-        $this->shopUrl = $shopUrl;
-        $this->shopId = $shopId;
-        $this->appVersion = $appVersion;
     }
 
     public function getShopUrl(): string

--- a/src/Exception/ShopwareResponseException.php
+++ b/src/Exception/ShopwareResponseException.php
@@ -6,6 +6,6 @@ class ShopwareResponseException extends \Exception
 {
     public function getResponse(): array
     {
-        return json_decode($this->message, true);
+        return json_decode((string) $this->message, true);
     }
 }

--- a/src/Exception/ShopwareSearchResponseException.php
+++ b/src/Exception/ShopwareSearchResponseException.php
@@ -6,12 +6,9 @@ use Vin\ShopwareSdk\Data\Criteria;
 
 class ShopwareSearchResponseException extends ShopwareResponseException
 {
-    private Criteria $criteria;
-
-    public function __construct(string $message, int $code, Criteria $criteria, \Throwable $throwable)
+    public function __construct(string $message, int $code, private readonly Criteria $criteria, \Throwable $throwable)
     {
         parent::__construct($message, $code, $throwable);
-        $this->criteria = $criteria;
     }
 
     public function getCriteria(): Criteria

--- a/src/Exception/WebhookAuthenticationException.php
+++ b/src/Exception/WebhookAuthenticationException.php
@@ -7,15 +7,8 @@ use Vin\ShopwareSdk\Data\Webhook\Shop;
 
 class WebhookAuthenticationException extends \Exception
 {
-    private Shop $shop;
-
-    private App $app;
-
-    public function __construct(string $message, Shop $shop, App $app)
+    public function __construct(string $message, private readonly Shop $shop, private readonly App $app)
     {
-        $this->shop = $shop;
-        $this->app = $app;
-
         parent::__construct($message, 401);
     }
 

--- a/src/Factory/RepositoryFactory.php
+++ b/src/Factory/RepositoryFactory.php
@@ -49,7 +49,7 @@ class RepositoryFactory
         try {
             $mapping = (string) file_get_contents(self::RESOURCES_PATH);
             self::$mapping = json_decode($mapping, true);
-        } catch (\JsonException $e) {
+        } catch (\JsonException) {
             throw new \RuntimeException('Could not load default entity mapping');
         }
     }

--- a/src/Hydrate/EntityHydrator.php
+++ b/src/Hydrate/EntityHydrator.php
@@ -13,18 +13,12 @@ use Vin\ShopwareSdk\Service\InfoService;
 
 class EntityHydrator implements HydratorInterface
 {
-    // using cache is recommended if you want to use circular references
-    protected bool $useCache;
-
     protected array $cache = [];
 
     protected array $cacheSchema = [];
 
-    public function __construct(
-        bool $useCache = false
-    )
+    public function __construct(protected bool $useCache = false)
     {
-        $this->useCache = $useCache;
     }
 
     public function schema(string $entity, Context $context): Schema

--- a/src/Hydrate/EntityHydrator.php
+++ b/src/Hydrate/EntityHydrator.php
@@ -2,7 +2,6 @@
 
 namespace Vin\ShopwareSdk\Hydrate;
 
-use Exception;
 use Vin\ShopwareSdk\Data\Context;
 use Vin\ShopwareSdk\Data\Entity\Custom\CustomDefinition;
 use Vin\ShopwareSdk\Data\Entity\Entity;
@@ -44,7 +43,7 @@ class EntityHydrator implements HydratorInterface
             $schema = $schemas->get($entity);
 
             if ($schema === null) {
-                throw new Exception('Schema for entity: ' . $entity . ' not found');
+                throw new \Exception('Schema for entity: ' . $entity . ' not found');
             }
         }
         
@@ -95,7 +94,7 @@ class EntityHydrator implements HydratorInterface
 
     private function hydrateEntity(string $entityName, array $entityRaw, array $data, Context $context): Entity
     {
-        if($this->useCache) {
+        if ($this->useCache) {
             $cacheKey = $entityRaw['type'] . '-' . $entityRaw['id'];
 
             if (array_key_exists($cacheKey, $this->cache)) {
@@ -121,7 +120,7 @@ class EntityHydrator implements HydratorInterface
         $relationships = $entityRaw['relationships'] ?? [];
 
         // reserve cache before relationships hydration. This prevents circular references to fail
-        if($this->useCache) {
+        if ($this->useCache) {
             $this->cache[$cacheKey] = $entity;
         }
 

--- a/src/Repository/EntityRepository.php
+++ b/src/Repository/EntityRepository.php
@@ -168,8 +168,7 @@ class EntityRepository implements RepositoryInterface
             $data = array_map(function (string $id) {
                 return ['id' => $id];
             }, $ids);
-        } else
-        {
+        } else {
             $data = $ids;
         }
 

--- a/src/Repository/EntityRepository.php
+++ b/src/Repository/EntityRepository.php
@@ -36,21 +36,12 @@ class EntityRepository implements RepositoryInterface
 
     private const SEARCH_IDS_API_ENDPOINT = '/api/search-ids';
 
-    public string $entityName;
-
-    public string $route;
-
     private HydratorInterface $hydrator;
 
-    private EntityDefinition $definition;
-
-    public function __construct(string $entityName, EntityDefinition $definition, string $route, ?HydratorInterface $hydrator = null)
+    public function __construct(public string $entityName, private EntityDefinition $definition, public string $route, ?HydratorInterface $hydrator = null)
     {
-        $this->entityName = $entityName;
-        $this->httpClient = $this->httpClient ?? $this->createHttpClient();
+        $this->httpClient ??= $this->createHttpClient();
         $this->hydrator = $hydrator ?: HydratorFactory::create();
-        $this->definition = $definition;
-        $this->route = $route;
     }
 
     public function getDefinition(): EntityDefinition
@@ -165,9 +156,7 @@ class EntityRepository implements RepositoryInterface
 
         if (!\is_array($ids[array_key_first($ids)]))
         {
-            $data = array_map(function (string $id) {
-                return ['id' => $id];
-            }, $ids);
+            $data = array_map(fn(string $id) => ['id' => $id], $ids);
         } else {
             $data = $ids;
         }

--- a/src/Repository/Struct/AggregationResultCollection.php
+++ b/src/Repository/Struct/AggregationResultCollection.php
@@ -13,10 +13,7 @@ class AggregationResultCollection
         }
     }
 
-    /**
-     * @param mixed $aggregation
-     */
-    public function add(string $key, $aggregation): void
+    public function add(string $key, mixed $aggregation): void
     {
         $this->elements[$key] = $aggregation;
     }

--- a/src/Repository/Struct/CloneBehaviour.php
+++ b/src/Repository/Struct/CloneBehaviour.php
@@ -6,14 +6,8 @@ use Vin\ShopwareSdk\Data\Struct;
 
 class CloneBehaviour extends Struct
 {
-    protected bool $cloneChildren;
-
-    protected array $overwrites;
-
-    public function __construct(bool $cloneChildren = true, array $overwrites = [])
+    public function __construct(protected bool $cloneChildren = true, protected array $overwrites = [])
     {
-        $this->cloneChildren = $cloneChildren;
-        $this->overwrites = $overwrites;
     }
 
     public function isCloneChildren(): bool

--- a/src/Repository/Struct/EntitySearchResult.php
+++ b/src/Repository/Struct/EntitySearchResult.php
@@ -9,34 +9,10 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
 
 class EntitySearchResult
 {
-    public SearchResultMeta $meta;
-
-    public Criteria $criteria;
-
-    public Context $context;
-
     public array $data = [];
 
-    public string $entityName;
-
-    public EntityCollection $entities;
-
-    public AggregationResultCollection $aggregations;
-
-    public function __construct(
-        string $entityName,
-        SearchResultMeta $meta,
-        EntityCollection $entities,
-        AggregationResultCollection $aggregations,
-        Criteria $criteria,
-        Context $context
-    ) {
-        $this->meta = $meta;
-        $this->criteria = $criteria;
-        $this->context = $context;
-        $this->entityName = $entityName;
-        $this->entities = $entities;
-        $this->aggregations = $aggregations;
+    public function __construct(public string $entityName, public SearchResultMeta $meta, public EntityCollection $entities, public AggregationResultCollection $aggregations, public Criteria $criteria, public Context $context)
+    {
     }
 
     public function getMeta(): SearchResultMeta

--- a/src/Repository/Struct/IdSearchResult.php
+++ b/src/Repository/Struct/IdSearchResult.php
@@ -8,23 +8,11 @@ use Vin\ShopwareSdk\Data\Utils\StringFormatter;
 
 class IdSearchResult
 {
-    private int $total;
-
-    private Criteria $criteria;
-
-    private Context $context;
-
-    private array $ids = [];
-
     private array $data = [];
 
-    public function __construct(int $total, array $ids, Criteria $criteria, Context $context)
+    public function __construct(private int $total, private array $ids, private Criteria $criteria, private Context $context)
     {
-        $this->total = $total;
-        $this->ids = $ids;
-        $this->data = $this->transformData($ids);
-        $this->criteria = $criteria;
-        $this->context = $context;
+        $this->data = $this->transformData($this->ids);
     }
 
     public function getTotal(): int
@@ -93,9 +81,7 @@ class IdSearchResult
         }
 
         if (is_string($data[0])) {
-            return array_map(function ($id) {
-                return ['id' => $id];
-            }, $data);
+            return array_map(fn($id) => ['id' => $id], $data);
         }
 
         return array_map(function ($value) {

--- a/src/Repository/Struct/SearchResultMeta.php
+++ b/src/Repository/Struct/SearchResultMeta.php
@@ -6,14 +6,8 @@ use Vin\ShopwareSdk\Data\Struct;
 
 class SearchResultMeta extends Struct
 {
-    private int $total;
-
-    private int $totalCountMode;
-
-    public function __construct(int $total, int $totalCountMode)
+    public function __construct(private int $total, private int $totalCountMode)
     {
-        $this->total = $total;
-        $this->totalCountMode = $totalCountMode;
     }
 
     public function getTotalCountMode(): int

--- a/src/Service/AdminSearchService.php
+++ b/src/Service/AdminSearchService.php
@@ -18,7 +18,7 @@ class AdminSearchService extends ApiService
 {
     private const ADMIN_SEARCH_ENDPOINT = '/api/_admin/search';
 
-    private HydratorInterface $hydrator;
+    private readonly HydratorInterface $hydrator;
 
     public function __construct(
         ?Context $context = null,
@@ -74,17 +74,15 @@ class AdminSearchService extends ApiService
 
                 $rawData = $itemResponse['data'] ?? [];
 
-                $rawData = array_map(function ($item) use ($entityName, $itemResponse) {
-                    return [
-                        'type' => $entityName,
-                        'id' => $item['id'],
-                        'attributes' => $item,
-                        'meta' => [
-                            'total' => $itemResponse['total'],
-                            'totalCountMode' => Criteria::TOTAL_COUNT_MODE_EXACT
-                        ],
-                    ];
-                }, $rawData);
+                $rawData = array_map(fn($item) => [
+                    'type' => $entityName,
+                    'id' => $item['id'],
+                    'attributes' => $item,
+                    'meta' => [
+                        'total' => $itemResponse['total'],
+                        'totalCountMode' => Criteria::TOTAL_COUNT_MODE_EXACT
+                    ],
+                ], $rawData);
 
                 $itemResponse['data'] = $rawData;
 

--- a/src/Service/ApiResponse.php
+++ b/src/Service/ApiResponse.php
@@ -5,17 +5,8 @@ namespace Vin\ShopwareSdk\Service;
 
 class ApiResponse
 {
-    private array $headers;
-
-    private array $contents;
-
-    private int $statusCode;
-
-    public function __construct(array $contents, array $headers, int $statusCode)
+    public function __construct(private readonly array $contents, private readonly array $headers, private readonly int $statusCode)
     {
-        $this->headers = $headers;
-        $this->contents = $contents;
-        $this->statusCode = $statusCode;
     }
 
     public function getHeaders(): array

--- a/src/Service/ApiService.php
+++ b/src/Service/ApiService.php
@@ -9,18 +9,12 @@ class ApiService
 {
     use CreateClientTrait;
 
-    protected ?Context $context = null;
-
-    protected string $contentType;
-
     /**
      * @deprecated tag v2.0.0 - $context will be remove, use setContext method instead
      */
-    public function __construct(?Context $context = null, string $contentType = 'application/vnd.api+json')
+    public function __construct(protected ?Context $context = null, protected string $contentType = 'application/vnd.api+json')
     {
-        $this->httpClient = $this->httpClient ?? $this->createHttpClient();
-        $this->context = $context;
-        $this->contentType = $contentType;
+        $this->httpClient ??= $this->createHttpClient();
     }
 
     public function setContext(Context $context): self

--- a/src/Service/MediaService.php
+++ b/src/Service/MediaService.php
@@ -18,7 +18,7 @@ class MediaService extends ApiService
      */
     public function uploadMediaById(string $mediaId, string $mimeType, $data, string $extension, ?string $fileName = null): ApiResponse
     {
-        $fileName = $fileName ?? $mediaId;
+        $fileName ??= $mediaId;
         $params = [
             'fileName' => $fileName,
             'extension' => $extension,

--- a/src/Service/Struct/KeyValuePair.php
+++ b/src/Service/Struct/KeyValuePair.php
@@ -6,8 +6,6 @@ use Vin\ShopwareSdk\Data\ParseAware;
 
 class KeyValuePair implements ParseAware
 {
-    private string $key;
-
     /**
      * @var mixed|null
      */
@@ -17,9 +15,8 @@ class KeyValuePair implements ParseAware
      * @param  string  $key
      * @param mixed|null $value
      */
-    private function __construct(string $key, $value)
+    private function __construct(private readonly string $key, $value)
     {
-        $this->key = $key;
         $this->value = $value ?? null;
     }
 

--- a/src/Service/Struct/Notification.php
+++ b/src/Service/Struct/Notification.php
@@ -15,20 +15,8 @@ class Notification extends Struct implements ParseAware
 
     public const INFO = 'info';
 
-    private string $status;
-
-    private string $message;
-
-    private bool $adminOnly;
-
-    private array $requiredPrivileges;
-
-    private function __construct(string $status, string $message, bool $adminOnly = false, array $requiredPrivileges = [])
+    private function __construct(private readonly string $status, private readonly string $message, private readonly bool $adminOnly = false, private readonly array $requiredPrivileges = [])
     {
-        $this->status = $status;
-        $this->message = $message;
-        $this->adminOnly = $adminOnly;
-        $this->requiredPrivileges = $requiredPrivileges;
     }
 
     public static function createNotificationSuccess(string $message, bool $adminOnly = false, array $requiredPrivileges = []): self

--- a/src/Service/Struct/NotificationCollection.php
+++ b/src/Service/Struct/NotificationCollection.php
@@ -6,12 +6,9 @@ use Vin\ShopwareSdk\Data\Collection;
 
 class NotificationCollection extends Collection
 {
-    private ?string $latestTimestamp;
-
-    public function __construct(iterable $elements = [], ?string $latestTimestamp = null)
+    public function __construct(iterable $elements = [], private readonly ?string $latestTimestamp = null)
     {
         parent::__construct($elements);
-        $this->latestTimestamp = $latestTimestamp;
     }
 
     public function getLatestTimestamp(): ?string

--- a/src/Service/Struct/SyncOperator.php
+++ b/src/Service/Struct/SyncOperator.php
@@ -11,21 +11,14 @@ class SyncOperator extends Struct implements ParseAware
 
     public const DELETE_OPERATOR = 'delete';
 
-    protected string $entity;
-
     protected string $action;
 
-    protected array $payload;
-
-    public function __construct(string $entity, string $action, array $payload)
+    public function __construct(protected string $entity, string $action, protected array $payload)
     {
         if ($action !== self::UPSERT_OPERATOR && $action !== self::DELETE_OPERATOR) {
             throw new \InvalidArgumentException('Action ' . $action . ' is not allowed, allowed types: upsert, delete');
         }
-
-        $this->entity = $entity;
         $this->action = $action;
-        $this->payload = $payload;
     }
 
     public function getEntity(): string

--- a/src/Service/SystemConfigService.php
+++ b/src/Service/SystemConfigService.php
@@ -143,7 +143,7 @@ class SystemConfigService extends ApiService
 
         /** @var KeyValuePair $item */
         foreach ($configs as $item) {
-            $parsed[$salesChannelId === null ? 'null' : $salesChannelId] = [$item->getKey() => $item->getValue()];
+            $parsed[$salesChannelId ?? 'null'] = [$item->getKey() => $item->getValue()];
         }
 
         try {

--- a/src/Service/WebhookAuthenticator.php
+++ b/src/Service/WebhookAuthenticator.php
@@ -16,7 +16,7 @@ class WebhookAuthenticator
 
         $queries = [];
 
-        parse_str($queryString, $queries);
+        parse_str((string) $queryString, $queries);
 
         if (!is_string($queries['shop-id']) || !is_string($queries['shop-url'])) {
             throw new \RuntimeException('shop-id and shop-url should be strings');
@@ -24,7 +24,7 @@ class WebhookAuthenticator
 
         $shop = new Shop($queries['shop-id'], $queries['shop-url']);
 
-        $hmac = \hash_hmac('sha256', htmlspecialchars_decode($queryString), $app->getAppSecret());
+        $hmac = \hash_hmac('sha256', htmlspecialchars_decode((string) $queryString), $app->getAppSecret());
 
         if (!hash_equals($hmac, $appSignature)) {
             throw new WebhookAuthenticationException(sprintf('Could not authenticate with store due to hash is not equals. Shopurl: %s', $shop->getShopUrl()), $shop, $app);
@@ -51,7 +51,7 @@ class WebhookAuthenticator
 
         $queries = [];
 
-        parse_str($queryString, $queries);
+        parse_str((string) $queryString, $queries);
 
         if (!is_string($queries['shop-id']) || !is_string($queries['shop-url'])) {
             throw new \RuntimeException('shop-id and shop-url should be strings');

--- a/tests/AdminAuthenticatorTest.php
+++ b/tests/AdminAuthenticatorTest.php
@@ -22,6 +22,7 @@ use Vin\ShopwareSdk\Exception\AuthorizationFailedException;
 class AdminAuthenticatorTest extends TestCase
 {
     private AdminAuthenticator $authenticator;
+
     private MockHandler $mock;
 
     protected function setUp(): void
@@ -77,7 +78,7 @@ class AdminAuthenticatorTest extends TestCase
 
         $accessToken = null;
 
-        $this->authenticator->setTokenCallback(function (AccessToken $response) use (&$accessToken) {
+        $this->authenticator->setTokenCallback(function (AccessToken $response) use (&$accessToken): void {
             $accessToken = $response;
         });
 

--- a/tests/EntityHydratorTest.php
+++ b/tests/EntityHydratorTest.php
@@ -24,7 +24,9 @@ use Vin\ShopwareSdk\Client\Client;
 class EntityHydratorTest extends TestCase
 {
     private EntityHydrator $entityHydrator;
+
     private MockHandler $mock;
+
     private Context $context;
 
     protected function setUp(): void


### PR DESCRIPTION
The support for PHP 8.0 ended in 2023. A PHP version that receives no security updates should not be supported.

The following changes were made:

- PHP 8.0 removed from composer
- development requirements updated bases on PHP 8.1
- ECS configuration updated based on version 12
- Rector added to support source code upgrades to PHP 8.1
- source code updated bases on PHP 8.1 (with rector)
- PHPStan configuration updated - PHPStan shows unresolved errors (also before the upgrade)