### PR TITLE
Criteria "fields"

### DIFF
--- a/src/Data/Criteria.php
+++ b/src/Data/Criteria.php
@@ -80,6 +80,8 @@ class Criteria implements ParseAware
 
     private array $includes = [];
 
+    private array $fields = [];
+
     /**
      * Default should be null to not limit artificily
      */
@@ -375,6 +377,10 @@ class Criteria implements ParseAware
             $params['includes'] = $this->includes;
         }
 
+        if (! empty($this->fields)) {
+            $params['fields'] = $this->fields;
+        }
+
         if ($this->totalCountMode !== null) {
             $params['total-count-mode'] = $this->totalCountMode;
         }
@@ -526,6 +532,34 @@ class Criteria implements ParseAware
     public function removeInclude(string $apiAlias): self
     {
         unset($this->includes[$apiAlias]);
+
+        return $this;
+    }
+
+    public function getFields(): array
+    {
+        return $this->fields;
+    }
+
+    public function setFields(array $fields): self
+    {
+        $this->fields = $fields;
+
+        return $this;
+    }
+
+    public function addField(string $field): self
+    {
+        $this->fields[] = $field;
+
+        return $this;
+    }
+
+    public function removeField(string $field): self
+    {
+        if (($key = array_search($field, $this->fields)) !== false) {
+            unset($this->fields[$key]);
+        }
 
         return $this;
     }

--- a/tests/CriteriaTest.php
+++ b/tests/CriteriaTest.php
@@ -63,6 +63,7 @@ class CriteriaTest extends TestCase
         $criteria->addQuery(new ScoreQuery(new EqualsAnyFilter('score-field', ['value-1', 'value-2']), 100, 'score-field'));
         $criteria->addInclude('product-alias', ['name', 'description']);
         $criteria->addGrouping('field-grouping');
+        $criteria->addField('productNumber');
 
         // Add multiple filter
         $criteria->addFilter(new EqualsFilter('field-1', 'value-1'));
@@ -260,6 +261,9 @@ class CriteriaTest extends TestCase
                     'name',
                     'description',
                 ],
+            ],
+            'fields' => [
+                'productNumber',
             ],
             'total-count-mode' => 1,
         ];


### PR DESCRIPTION
The Shopware API provides two ways to reduce the performance impact and the size of a response.

1) "includes"
The object contains entity fields, grouped by the source entity api alias, that should be included in the response. It's described here: https://developer.shopware.com/docs/guides/integrations-api/general-concepts/search-criteria.html . Internally "includes" is processed by the Shopware serializer. It will just ignore everything that is not a default field and not included in the "includes" object of the request.

2) "fields"
The array looks quite similar to the "includes" object and the results can be the same. While "includes" is processed by the serializer, "fields" is used by the DAL itself. Entity fields that are not listed there will not be queried by the DAL. The "fields" array is mentioned here: https://developer.shopware.com/docs/guides/integrations-api/general-concepts/partial-data-loading.html . It uses point notation for the path to the entity field.

The combined usage of "includes" and "fields" can greatly improve the response time and reduce the performance usage of Shopware. It's ideal for things like querying for all product numbers in the catalog or if basic information (more than the ID) of a related entity is required but not the entire entity (product number, customer number, image name, ...).