### PR TITLE
Mandatory `getEntityNames` method added to `DefinitionCollectionProvider` interface

### DIFF
--- a/src/Definition/DefinitionCollectionPopulator.php
+++ b/src/Definition/DefinitionCollectionPopulator.php
@@ -6,6 +6,11 @@ namespace Vin\ShopwareSdk\Definition;
 
 interface DefinitionCollectionPopulator
 {
+    /**
+     * @return string[]
+     */
+    public static function getEntityNames(string $shopwareVersion): array;
+
     public static function priority(): int;
 
     public function populateDefinitionCollection(DefinitionCollection $definitionCollection, string $shopwareVersion): void;

--- a/src/Definition/EntityDefinitionCollectionPopulator/WithSdkMapping.php
+++ b/src/Definition/EntityDefinitionCollectionPopulator/WithSdkMapping.php
@@ -10,6 +10,13 @@ use Vin\ShopwareSdk\Definition\DefinitionCollectionPopulator;
 
 final class WithSdkMapping implements DefinitionCollectionPopulator
 {
+    public static function getEntityNames(string $shopwareVersion): array
+    {
+        $mapping = self::loadEntityMapping($shopwareVersion);
+
+        return array_keys($mapping);
+    }
+
     public static function priority(): int
     {
         return 1000;
@@ -17,11 +24,7 @@ final class WithSdkMapping implements DefinitionCollectionPopulator
 
     public function populateDefinitionCollection(DefinitionCollection $definitionCollection, string $shopwareVersion): void
     {
-        $entityMappingFileName = sprintf('entity_mapping_%s.json', $shopwareVersion);
-        $entityMappingPath = __DIR__ . '/../../Resources/' . $entityMappingFileName;
-        $jsonEncodedMapping = (string) file_get_contents($entityMappingPath);
-        /** @var array<string, class-string<EntityDefinition>> $mapping */
-        $mapping = json_decode($jsonEncodedMapping, true);
+        $mapping = self::loadEntityMapping($shopwareVersion);
 
         foreach ($mapping as $definitionClass) {
             if (! class_exists($definitionClass)) {
@@ -30,5 +33,19 @@ final class WithSdkMapping implements DefinitionCollectionPopulator
 
             $definitionCollection->set(new $definitionClass());
         }
+    }
+
+    /**
+     * @return array<string, class-string<EntityDefinition>>
+     */
+    private static function loadEntityMapping(string $shopwareVersion): array
+    {
+        $entityMappingFileName = sprintf('entity_mapping_%s.json', $shopwareVersion);
+        $entityMappingPath = __DIR__ . '/../../Resources/' . $entityMappingFileName;
+        $jsonEncodedMapping = (string) file_get_contents($entityMappingPath);
+        /** @var array<string, class-string<EntityDefinition>> $mapping */
+        $mapping = json_decode($jsonEncodedMapping, true);
+
+        return $mapping;
     }
 }


### PR DESCRIPTION
The `getEntityNames` method was added to the `DefinitionCollectionProvider` interface to be used in the Shopware SDK Symfony bundle. It will be used to register all entity repositories to be autowireable via dependency injection.