### PR TITLE
Rector rules extension and application

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -3,16 +3,95 @@
 declare(strict_types=1);
 
 use Rector\Caching\ValueObject\Storage\FileCacheStorage;
+use Rector\CodeQuality\Rector\Foreach_\SimplifyForeachToCoalescingRector;
+use Rector\CodeQuality\Rector\Identical\FlipTypeControlToUseExclusiveTypeRector;
+use Rector\CodeQuality\Rector\If_\ConsecutiveNullCompareReturnsToNullCoalesceQueueRector;
+use Rector\CodeQuality\Rector\If_\SimplifyIfNotNullReturnRector;
+use Rector\CodeQuality\Rector\If_\SimplifyIfNullableReturnRector;
+use Rector\CodeQuality\Rector\Isset_\IssetOnPropertyObjectToPropertyExistsRector;
+use Rector\CodeQuality\Rector\NullsafeMethodCall\CleanupUnneededNullsafeOperatorRector;
+use Rector\CodeQuality\Rector\Ternary\ArrayKeyExistsTernaryThenValueToCoalescingRector;
+use Rector\CodingStyle\Rector\If_\NullableCompareToNullRector;
 use Rector\Config\RectorConfig;
-use Rector\Set\ValueObject\LevelSetList;
+use Rector\EarlyReturn\Rector\Foreach_\ChangeNestedForeachIfsToEarlyContinueRector;
+use Rector\EarlyReturn\Rector\If_\ChangeIfElseValueAssignToEarlyReturnRector;
+use Rector\EarlyReturn\Rector\If_\ChangeOrIfContinueToMultiContinueRector;
+use Rector\EarlyReturn\Rector\If_\RemoveAlwaysElseRector;
+use Rector\EarlyReturn\Rector\Return_\PreparedValueToEarlyReturnRector;
+use Rector\EarlyReturn\Rector\Return_\ReturnBinaryOrToEarlyReturnRector;
+use Rector\EarlyReturn\Rector\StmtsAwareInterface\ReturnEarlyIfVariableRector;
+use Rector\Php74\Rector\Property\RestoreDefaultNullToNullableTypePropertyRector;
+use Rector\Php84\Rector\Param\ExplicitNullableParamTypeRector;
+use Rector\PHPUnit\Set\PHPUnitSetList;
+use Rector\Set\ValueObject\SetList;
+use Rector\TypeDeclaration\Rector\BooleanAnd\BinaryOpNullableToInstanceofRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromSymfonySerializerRector;
+use Rector\TypeDeclaration\Rector\Empty_\EmptyOnNullableObjectToInstanceOfRector;
+use Rector\TypeDeclaration\Rector\StmtsAwareInterface\DeclareStrictTypesRector;
+use Rector\TypeDeclaration\Rector\While_\WhileNullableToInstanceofRector;
+use Rector\ValueObject\PhpVersion;
 
 return RectorConfig::configure()
-    ->withPaths([
-        __DIR__ . '/src',
-        __DIR__ . '/tests',
-    ])
-    ->withSets([LevelSetList::UP_TO_PHP_83])
+    ->withPaths([__DIR__ . '/src', __DIR__ . '/tests',])
+    ->withSkipPath(__DIR__ . '/src/Data/Entity')
+
     ->withCache(
         cacheDirectory: '/tmp/rector',
         cacheClass: FileCacheStorage::class
+    )
+
+    ->withPhpVersion(PhpVersion::PHP_83)
+
+    ->withSets([
+        SetList::PHP_74,
+        SetList::PHP_80,
+        SetList::PHP_81,
+        SetList::PHP_82,
+        SetList::PHP_83,
+        PHPUnitSetList::PHPUNIT_100,
+        PHPUnitSetList::PHPUNIT_CODE_QUALITY,
+    ])
+
+    ->withImportNames(importShortClasses: false, removeUnusedImports: true)
+
+    ->withRules(
+        [
+            DeclareStrictTypesRector::class,
+            ChangeIfElseValueAssignToEarlyReturnRector::class,
+            ChangeNestedForeachIfsToEarlyContinueRector::class,
+            ChangeOrIfContinueToMultiContinueRector::class,
+            PreparedValueToEarlyReturnRector::class,
+            RemoveAlwaysElseRector::class,
+            ReturnBinaryOrToEarlyReturnRector::class,
+            ReturnEarlyIfVariableRector::class,
+            AddVoidReturnTypeWhereNoReturnRector::class,
+            ArrayKeyExistsTernaryThenValueToCoalescingRector::class,
+            CleanupUnneededNullsafeOperatorRector::class,
+            ConsecutiveNullCompareReturnsToNullCoalesceQueueRector::class,
+            FlipTypeControlToUseExclusiveTypeRector::class,
+            IssetOnPropertyObjectToPropertyExistsRector::class,
+            SimplifyForeachToCoalescingRector::class,
+            SimplifyIfNotNullReturnRector::class,
+            BinaryOpNullableToInstanceofRector::class,
+            EmptyOnNullableObjectToInstanceOfRector::class,
+            ExplicitNullableParamTypeRector::class,
+            NullableCompareToNullRector::class,
+            RestoreDefaultNullToNullableTypePropertyRector::class,
+            SimplifyIfNullableReturnRector::class,
+            WhileNullableToInstanceofRector::class,
+            ReturnTypeFromSymfonySerializerRector::class,
+        ]
+    )
+
+    ->withPreparedSets(
+        deadCode: true,
+        codeQuality: true,
+        codingStyle: true,
+        typeDeclarations: true,
+        privatization: false,
+        naming: false,
+        instanceOf: true,
+        earlyReturn: true,
+        strictBooleans: true
     );

--- a/src/Auth/AccessTokenFetcher/SimpleFetcher.php
+++ b/src/Auth/AccessTokenFetcher/SimpleFetcher.php
@@ -43,8 +43,8 @@ final readonly class SimpleFetcher implements AccessTokenFetcher
 
         try {
             $tokenData = $this->responseParser->getDecodedResponseContent($response);
-        } catch (ShopwareResponseException $exception) {
-            throw new AuthorizationFailedException($exception->getMessage(), $exception->getCode(), $exception);
+        } catch (ShopwareResponseException $shopwareResponseException) {
+            throw new AuthorizationFailedException($shopwareResponseException->getMessage(), $shopwareResponseException->getCode(), $shopwareResponseException);
         }
 
         if (array_key_exists('access_token', $tokenData) === false || is_string($tokenData['access_token']) === false) {

--- a/src/Auth/GrantType.php
+++ b/src/Auth/GrantType.php
@@ -34,6 +34,7 @@ abstract class GrantType
         if (! \in_array($grantType, self::ALLOWED_GRANTS)) {
             throw new \InvalidArgumentException('Grant type ' . $grantType . ' is not supported', 400);
         }
+
         $this->grantType = $grantType;
     }
 

--- a/src/Data/Aggregation/FilterAggregation.php
+++ b/src/Data/Aggregation/FilterAggregation.php
@@ -24,7 +24,7 @@ class FilterAggregation extends Aggregation
         return [
             'type' => self::TYPE_FILTER,
             'name' => $this->name,
-            'filter' => array_map(fn (Filter $filter) => $filter->parse(), $this->filter),
+            'filter' => array_map(fn (Filter $filter): array => $filter->parse(), $this->filter),
             'aggregation' => $this->aggregation->parse(),
         ];
     }

--- a/src/Data/Aggregation/HistogramAggregation.php
+++ b/src/Data/Aggregation/HistogramAggregation.php
@@ -46,7 +46,7 @@ class HistogramAggregation extends Aggregation
                 'field' => $this->field,
                 'interval' => $this->interval,
                 'format' => $this->format,
-                'aggregation' => $this->aggregation ? $this->aggregation->parse() : null,
+                'aggregation' => $this->aggregation instanceof Aggregation ? $this->aggregation->parse() : null,
             ]
         );
     }

--- a/src/Data/Aggregation/TermsAggregation.php
+++ b/src/Data/Aggregation/TermsAggregation.php
@@ -32,8 +32,8 @@ class TermsAggregation extends Aggregation
                 'name' => $this->name,
                 'field' => $this->field,
                 'limit' => $this->limit,
-                'sort' => $this->sort ? $this->sort->parse() : null,
-                'aggregation' => $this->aggregation ? $this->aggregation->parse() : null,
+                'sort' => $this->sort instanceof FieldSorting ? $this->sort->parse() : null,
+                'aggregation' => $this->aggregation instanceof Aggregation ? $this->aggregation->parse() : null,
             ]
         );
     }

--- a/src/Data/Collection.php
+++ b/src/Data/Collection.php
@@ -10,7 +10,7 @@ abstract class Collection extends Struct implements \IteratorAggregate, \Countab
 
     public function __construct(iterable $elements = [])
     {
-        $elements = $elements instanceof \Traversable ? iterator_to_array($elements) : (array) $elements;
+        $elements = $elements instanceof \Traversable ? iterator_to_array($elements) : $elements;
 
         foreach ($elements as $key => $element) {
             $this->set($key, $element);
@@ -109,7 +109,7 @@ abstract class Collection extends Struct implements \IteratorAggregate, \Countab
      */
     public function filterInstance(string $class)
     {
-        return $this->filter(static fn ($item) => $item instanceof $class);
+        return $this->filter(static fn ($item): bool => $item instanceof $class);
     }
 
     /**
@@ -136,7 +136,7 @@ abstract class Collection extends Struct implements \IteratorAggregate, \Countab
     #[\Override]
     public function jsonSerialize(): array
     {
-        return array_values(array_map(fn (Struct $element) => $element->jsonSerialize(), $this->elements));
+        return array_values(array_map(fn (Struct $element): array => $element->jsonSerialize(), $this->elements));
     }
 
     public function first(): ?Struct

--- a/src/Data/Criteria.php
+++ b/src/Data/Criteria.php
@@ -305,7 +305,7 @@ class Criteria implements ParseAware
     {
         $params = [];
 
-        if (! empty($this->ids)) {
+        if ($this->ids !== []) {
             $params['ids'] = \implode('|', $this->ids);
         }
 
@@ -319,7 +319,7 @@ class Criteria implements ParseAware
             $params['term'] = $this->term;
         }
 
-        if (! empty($this->queries)) {
+        if ($this->queries !== []) {
             $params['query'] = [];
 
             foreach ($this->queries as $query) {
@@ -327,7 +327,7 @@ class Criteria implements ParseAware
             }
         }
 
-        if (! empty($this->filters)) {
+        if ($this->filters !== []) {
             $params['filter'] = [];
 
             foreach ($this->filters as $filter) {
@@ -335,7 +335,7 @@ class Criteria implements ParseAware
             }
         }
 
-        if (! empty($this->postFilter)) {
+        if ($this->postFilter !== []) {
             $params['post-filter'] = [];
 
             foreach ($this->postFilter as $postFilter) {
@@ -343,7 +343,7 @@ class Criteria implements ParseAware
             }
         }
 
-        if (! empty($this->sortings)) {
+        if ($this->sortings !== []) {
             $params['sort'] = [];
 
             foreach ($this->sortings as $sorting) {
@@ -351,22 +351,22 @@ class Criteria implements ParseAware
             }
         }
 
-        if (! empty($this->aggregations)) {
+        if ($this->aggregations !== []) {
             $params['aggregations'] = [];
             foreach ($this->aggregations as $aggregation) {
                 $params['aggregations'][] = $aggregation->parse();
             }
         }
 
-        if (! empty($this->groupFields)) {
+        if ($this->groupFields !== []) {
             $params['groupFields'] = $this->groupFields;
         }
 
-        if (! empty($this->grouping)) {
+        if ($this->grouping !== []) {
             $params['grouping'] = $this->grouping;
         }
 
-        if (! empty($this->associations)) {
+        if ($this->associations !== []) {
             $params['associations'] = [];
 
             foreach ($this->associations as $association) {
@@ -374,11 +374,11 @@ class Criteria implements ParseAware
             }
         }
 
-        if (! empty($this->includes)) {
+        if ($this->includes !== []) {
             $params['includes'] = $this->includes;
         }
 
-        if (! empty($this->fields)) {
+        if ($this->fields !== []) {
             $params['fields'] = $this->fields;
         }
 
@@ -558,7 +558,7 @@ class Criteria implements ParseAware
 
     public function removeField(string $field): self
     {
-        if (($key = array_search($field, $this->fields)) !== false) {
+        if (($key = array_search($field, $this->fields, true)) !== false) {
             unset($this->fields[$key]);
         }
 

--- a/src/Data/CriteriaCollection.php
+++ b/src/Data/CriteriaCollection.php
@@ -27,12 +27,6 @@ class CriteriaCollection extends Collection
         throw new \RuntimeException('Criteria have to be added with an entity name. Use `set` method instead.');
     }
 
-    #[\Override]
-    public function getExpectedClass(): string
-    {
-        return Criteria::class;
-    }
-
     /**
      * @return array<string, array<string, mixed>>
      */
@@ -59,5 +53,11 @@ class CriteriaCollection extends Collection
         }
 
         parent::set($key, $element);
+    }
+
+    #[\Override]
+    protected function getExpectedClass(): string
+    {
+        return Criteria::class;
     }
 }

--- a/src/Data/Filter/MultiFilter.php
+++ b/src/Data/Filter/MultiFilter.php
@@ -27,7 +27,7 @@ class MultiFilter extends Filter
         return [
             'type' => self::TYPE_MULTI,
             'operator' => $this->operator,
-            'queries' => array_map(fn (Filter $filter) => $filter->parse(), $this->queries),
+            'queries' => array_map(fn (Filter $filter): array => $filter->parse(), $this->queries),
         ];
     }
 }

--- a/src/Data/Filter/NotFilter.php
+++ b/src/Data/Filter/NotFilter.php
@@ -27,7 +27,7 @@ class NotFilter extends Filter
         return [
             'type' => self::TYPE_NOT,
             'operator' => $this->operator,
-            'queries' => array_map(fn (Filter $filter) => $filter->parse(), $this->queries),
+            'queries' => array_map(fn (Filter $filter): array => $filter->parse(), $this->queries),
         ];
     }
 }

--- a/src/Data/Schema/FlagCollection.php
+++ b/src/Data/Schema/FlagCollection.php
@@ -15,7 +15,7 @@ class FlagCollection extends Collection
 {
     public function __construct(iterable $elements = [])
     {
-        $elements = $elements instanceof \Traversable ? iterator_to_array($elements) : (array) $elements;
+        $elements = $elements instanceof \Traversable ? iterator_to_array($elements) : $elements;
 
         /** @var Flag $element */
         foreach ($elements as $element) {

--- a/src/Data/Schema/PropertyCollection.php
+++ b/src/Data/Schema/PropertyCollection.php
@@ -15,7 +15,7 @@ class PropertyCollection extends Collection
 {
     public function __construct(iterable $elements = [])
     {
-        $elements = $elements instanceof \Traversable ? iterator_to_array($elements) : (array) $elements;
+        $elements = $elements instanceof \Traversable ? iterator_to_array($elements) : $elements;
 
         /** @var Property $element */
         foreach ($elements as $element) {

--- a/src/Data/Schema/SchemaCollection.php
+++ b/src/Data/Schema/SchemaCollection.php
@@ -15,7 +15,7 @@ class SchemaCollection extends Collection
 {
     public function __construct(iterable $elements = [])
     {
-        $elements = $elements instanceof \Traversable ? iterator_to_array($elements) : (array) $elements;
+        $elements = $elements instanceof \Traversable ? iterator_to_array($elements) : $elements;
 
         /** @var Schema $element */
         foreach ($elements as $element) {

--- a/src/Data/Struct.php
+++ b/src/Data/Struct.php
@@ -6,6 +6,8 @@ namespace Vin\ShopwareSdk\Data;
 
 class Struct
 {
+    public string $id;
+
     /**
      * @var Struct[]
      */
@@ -16,8 +18,8 @@ class Struct
         try {
             $self = (new \ReflectionClass(static::class))
                 ->newInstanceWithoutConstructor();
-        } catch (\ReflectionException $exception) {
-            throw new \InvalidArgumentException($exception->getMessage());
+        } catch (\ReflectionException $reflectionException) {
+            throw new \InvalidArgumentException($reflectionException->getMessage(), $reflectionException->getCode(), $reflectionException);
         }
 
         foreach (get_object_vars($object) as $property => $value) {
@@ -92,7 +94,7 @@ class Struct
     {
         $extension = $this->getExtension($name);
 
-        return $extension !== null && $extension::class === $type;
+        return $extension instanceof \Vin\ShopwareSdk\Data\Struct && $extension::class === $type;
     }
 
     public function getExtensions(): array

--- a/src/Data/Uuid/Uuid.php
+++ b/src/Data/Uuid/Uuid.php
@@ -51,6 +51,7 @@ class Uuid
         if (mb_strlen($bytes, '8bit') !== 16) {
             throw new InvalidUuidLengthException(mb_strlen($bytes, '8bit'), bin2hex($bytes));
         }
+
         $uuid = bin2hex($bytes);
 
         if (! self::isValid($uuid)) {
@@ -94,32 +95,23 @@ class Uuid
 
     public static function isValid(string $id): bool
     {
-        if (! preg_match('/' . self::VALID_PATTERN . '/', $id)) {
-            return false;
-        }
-
-        return true;
+        return (bool) preg_match('/' . self::VALID_PATTERN . '/', $id);
     }
 
     private static function applyVersion(string $timeHi, int $version): int
     {
         $timeHi = hexdec($timeHi) & 0x0fff;
         $timeHi &= ~(0xf000);
-        $timeHi |= $version << 12;
 
-        return $timeHi;
+        return $timeHi | $version << 12;
     }
 
-    /**
-     * @param int|float $clockSeqHi
-     */
-    private static function applyVariant($clockSeqHi): int
+    private static function applyVariant(float|int $clockSeqHi): int
     {
         // Set the variant to RFC 4122
         $clockSeqHi &= 0x3f;
         $clockSeqHi &= ~(0xc0);
-        $clockSeqHi |= 0x80;
 
-        return $clockSeqHi;
+        return $clockSeqHi | 0x80;
     }
 }

--- a/src/Data/Webhook/AppAction/AppAction.php
+++ b/src/Data/Webhook/AppAction/AppAction.php
@@ -42,8 +42,9 @@ class AppAction extends Struct
 
     public static function createFromPayload(array $payload, ?array $headers = []): self
     {
-        $source = $action = $meta = null;
-
+        $source = null;
+        $action = null;
+        $meta = null;
         if ($rawSource = $payload['source']) {
             $source = new Source($rawSource['url'], $rawSource['shopId'], (string) $rawSource['appVersion']);
         }

--- a/src/Data/Webhook/Event/Event.php
+++ b/src/Data/Webhook/Event/Event.php
@@ -42,16 +42,14 @@ class Event extends Struct
 
     public static function createFromPayload(array $payload, ?array $headers = []): self
     {
-        $source = $data = null;
-
+        $source = null;
+        $data = null;
         if ($rawSource = $payload['source']) {
             $source = new Source($rawSource['url'], $rawSource['shopId'], (string) $rawSource['appVersion']);
         }
 
-        if ($rawData = $payload['data']) {
-            if (! empty($rawData['payload'])) {
-                $data = new EventData($rawData['event'], $rawData['payload']);
-            }
+        if (($rawData = $payload['data']) && ! empty($rawData['payload'])) {
+            $data = new EventData($rawData['event'], $rawData['payload']);
         }
 
         return new self($source, $data, (int) ($payload['timestamp'] ?? 0), $headers ?? []);

--- a/src/Http/RequestFactory.php
+++ b/src/Http/RequestFactory.php
@@ -76,6 +76,7 @@ final readonly class RequestFactory implements RequestFactoryInterface
 
             return $request->withBody($body);
         }
+
         if (is_resource($data)) {
             $body = $this->streamFactory->createStreamFromResource($data);
 

--- a/src/Hydrate/Result/EntityResult.php
+++ b/src/Hydrate/Result/EntityResult.php
@@ -71,6 +71,7 @@ final class EntityResult
 
         $this->entity = new $entityClass();
         $this->entity->internalSetEntityName($this->entityName);
+
         $this->entity->id = $this->id;
         $attributeHydrator->hydrateAttributes($this->entity, $this->entityName, $this->attributes);
     }

--- a/src/Hydrate/Service/ExtensionParser.php
+++ b/src/Hydrate/Service/ExtensionParser.php
@@ -16,9 +16,11 @@ final class ExtensionParser implements ExtensionParserInterface
             if ($propertyName !== 'extensions') {
                 continue;
             }
+
             if (array_key_exists('data', $extensionData) === false) {
                 continue;
             }
+
             if (is_array($extensionData['data']) === false) {
                 continue;
             }

--- a/src/Hydrate/Service/RelationshipsParser.php
+++ b/src/Hydrate/Service/RelationshipsParser.php
@@ -22,6 +22,7 @@ final class RelationshipsParser implements RelationshipsParserInterface
             if (array_key_exists('data', $relationship) === false) {
                 continue;
             }
+
             if (is_array($relationship['data']) === false) {
                 continue;
             }

--- a/src/Repository/EntityRepository.php
+++ b/src/Repository/EntityRepository.php
@@ -36,7 +36,7 @@ final readonly class EntityRepository implements RepositoryInterface
     public function clone(string $id, ?CloneBehaviour $cloneBehaviour = null): string
     {
         $data = [];
-        if ($cloneBehaviour) {
+        if ($cloneBehaviour instanceof CloneBehaviour) {
             $data = $cloneBehaviour->jsonSerialize();
         }
 
@@ -88,6 +88,7 @@ final readonly class EntityRepository implements RepositoryInterface
         if (is_string($versionId)) {
             $data['versionId'] = $versionId;
         }
+
         if (is_string($versionName)) {
             $data['versionName'] = $versionName;
         }
@@ -203,6 +204,7 @@ final readonly class EntityRepository implements RepositoryInterface
         if (empty($data['id'])) {
             throw new \InvalidArgumentException('Id is not provided for update payload');
         }
+
         $id = $data['id'];
 
         $context = $this->buildContext();

--- a/src/Repository/Struct/EntitySearchResultCollection.php
+++ b/src/Repository/Struct/EntitySearchResultCollection.php
@@ -29,12 +29,6 @@ class EntitySearchResultCollection extends Collection
         throw new \RuntimeException('EntitySearchResults have to be added with an entity name. Use `set` method instead.');
     }
 
-    #[\Override]
-    public function getExpectedClass(): string
-    {
-        return EntitySearchResult::class;
-    }
-
     /**
      * @param string $key
      * @param EntitySearchResult $element
@@ -47,5 +41,11 @@ class EntitySearchResultCollection extends Collection
         }
 
         parent::set($key, $element);
+    }
+
+    #[\Override]
+    protected function getExpectedClass(): string
+    {
+        return EntitySearchResult::class;
     }
 }

--- a/src/Repository/Struct/IdSearchResult.php
+++ b/src/Repository/Struct/IdSearchResult.php
@@ -73,7 +73,7 @@ class IdSearchResult
 
     public function firstId(): ?string
     {
-        if (empty($this->ids)) {
+        if ($this->ids === []) {
             return null;
         }
 
@@ -82,17 +82,17 @@ class IdSearchResult
 
     private function transformData(array $data): array
     {
-        if (empty($data)) {
+        if ($data === []) {
             return [];
         }
 
         if (is_string($data[0])) {
-            return array_map(fn ($id) => [
+            return array_map(fn ($id): array => [
                 'id' => $id,
             ], $data);
         }
 
-        return array_map(function ($value) {
+        return array_map(function ($value): array {
             $transformed = [];
 
             foreach ($value as $key => $item) {

--- a/src/Repository/Struct/VersionResponse.php
+++ b/src/Repository/Struct/VersionResponse.php
@@ -8,11 +8,11 @@ use Vin\ShopwareSdk\Data\Struct;
 
 class VersionResponse extends Struct
 {
+    public string $id;
+
     protected string $versionId;
 
     protected ?string $versionName;
-
-    protected string $id;
 
     protected string $entity;
 

--- a/src/Service/AdminSearchService.php
+++ b/src/Service/AdminSearchService.php
@@ -34,7 +34,7 @@ final readonly class AdminSearchService implements AdminSearchServiceInterface
             $itemResponse = $data[$entityName] ?? [];
             $rawData = $itemResponse['data'] ?? [];
 
-            $rawData = array_map(fn ($item) => [
+            $rawData = array_map(fn ($item): array => [
                 'type' => $entityName,
                 'id' => $item['id'],
                 'attributes' => $item,

--- a/src/Service/Api/ApiService.php
+++ b/src/Service/Api/ApiService.php
@@ -105,7 +105,7 @@ final readonly class ApiService implements ApiServiceInterface
     private function buildPath(string $endpoint, array $params): string
     {
         $path = $endpoint;
-        if (count($params) > 0) {
+        if ($params !== []) {
             $path .= '?' . http_build_query($params);
         }
 

--- a/src/Service/InfoService.php
+++ b/src/Service/InfoService.php
@@ -71,7 +71,7 @@ final class InfoService implements InfoServiceInterface
             return $this->cache[$entity];
         }
 
-        if ($this->schema !== null) {
+        if ($this->schema instanceof SchemaCollection) {
             return $this->schema->get($entity);
         }
 
@@ -81,6 +81,7 @@ final class InfoService implements InfoServiceInterface
         if (is_bool($localSchema) && $localSchema === false) {
             $this->schema = $this->refreshSchema();
         }
+
         if (is_string($localSchema)) {
             $decodedResponse = \json_decode($localSchema, true) ?? [];
             $this->schema = $this->parseSchema($decodedResponse);

--- a/src/Service/Struct/SyncOperator.php
+++ b/src/Service/Struct/SyncOperator.php
@@ -23,6 +23,7 @@ class SyncOperator extends Struct implements ParseAware
         if ($action !== self::UPSERT_OPERATOR && $action !== self::DELETE_OPERATOR) {
             throw new \InvalidArgumentException('Action ' . $action . ' is not allowed, allowed types: upsert, delete');
         }
+
         $this->action = $action;
     }
 

--- a/tests/Auth/AccessTokenFetcher/SimpleFetcherTest.php
+++ b/tests/Auth/AccessTokenFetcher/SimpleFetcherTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Vin\ShopwareSdkTest\Auth\AccessTokenFetcher;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -125,9 +126,9 @@ final class SimpleFetcherTest extends TestCase
 
         $requestFactory->expects($this->once())
             ->method('createRequest')
-            ->willReturnCallback(function (string $uri, array $data) use ($expectedUri, $expectedData, $request) {
-                $this->assertEquals($expectedUri, $uri);
-                $this->assertEquals($expectedData, json_encode($data));
+            ->willReturnCallback(function (string $uri, array $data) use ($expectedUri, $expectedData, $request): MockObject {
+                $this->assertSame($expectedUri, $uri);
+                $this->assertSame($expectedData, json_encode($data));
 
                 return $request;
             });
@@ -138,7 +139,7 @@ final class SimpleFetcherTest extends TestCase
 
         $clientInterface->expects($this->once())
             ->method('sendRequest')
-            ->willReturnCallback(function ($passedRequest) use ($request, $response) {
+            ->willReturnCallback(function ($passedRequest) use ($request, $response): MockObject {
                 $this->assertEquals($request, $passedRequest);
 
                 return $response;
@@ -146,9 +147,9 @@ final class SimpleFetcherTest extends TestCase
 
         $accessToken = $accessTokenFetcher->fetchAccessToken($grantType);
         $this->assertInstanceOf(AccessToken::class, $accessToken);
-        $this->assertEquals($expectedTokenType, $accessToken->tokenType);
-        $this->assertEquals($expectedAccessToken, $accessToken->accessToken);
-        $this->assertEquals($expectedExpiresIn, $accessToken->expiresIn);
+        $this->assertSame($expectedTokenType, $accessToken->tokenType);
+        $this->assertSame($expectedAccessToken, $accessToken->accessToken);
+        $this->assertSame($expectedExpiresIn, $accessToken->expiresIn);
         $this->assertEquals($expectedRefreshToken, $accessToken->refreshToken);
     }
 }

--- a/tests/Auth/AccessTokenFetcher/TokenRequestFactoryTest.php
+++ b/tests/Auth/AccessTokenFetcher/TokenRequestFactoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Vin\ShopwareSdkTest\Auth\AccessTokenFetcher;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -41,7 +42,7 @@ final class TokenRequestFactoryTest extends TestCase
         $withHeaderMethodCall = 0;
         $request->expects($this->exactly(2))
             ->method('withHeader')
-            ->willReturnCallback(function (string $name, $value) use (&$withHeaderMethodCall, $request) {
+            ->willReturnCallback(function (string $name, $value) use (&$withHeaderMethodCall, $request): MockObject {
                 $passedHeaders = [[
                     'Accept' => 'application/json',
                 ], [
@@ -56,7 +57,7 @@ final class TokenRequestFactoryTest extends TestCase
             });
         $request->expects($this->exactly(1))
             ->method('withBody')
-            ->willReturnCallback(function ($body) use ($formData, $request) {
+            ->willReturnCallback(function ($body) use ($formData, $request): MockObject {
                 $this->assertEquals(json_encode($formData), (string) $body);
 
                 return $request;
@@ -64,7 +65,7 @@ final class TokenRequestFactoryTest extends TestCase
 
         $streamFactory->expects($this->once())
             ->method('createStream')
-            ->willReturnCallback(function (string $body) {
+            ->willReturnCallback(function (string $body): MockObject {
                 $stream = $this->createMock(StreamInterface::class);
                 $stream->expects($this->once())
                     ->method('__toString')

--- a/tests/Auth/AccessTokenProvider/WithClientCredentialsTest.php
+++ b/tests/Auth/AccessTokenProvider/WithClientCredentialsTest.php
@@ -41,10 +41,10 @@ final class WithClientCredentialsTest extends TestCase
         $accessTokenFetcher->expects($this->once())
             ->method('fetchAccessToken')
             ->with($this->isInstanceOf(ClientCredentialsGrantType::class))
-            ->willReturnCallback(function ($grantType) use ($clientId, $clientSecret) {
+            ->willReturnCallback(function ($grantType) use ($clientId, $clientSecret): AccessToken {
                 $this->assertInstanceOf(ClientCredentialsGrantType::class, $grantType);
-                $this->assertEquals($clientId, $grantType->clientId);
-                $this->assertEquals($clientSecret, $grantType->clientSecret);
+                $this->assertSame($clientId, $grantType->clientId);
+                $this->assertSame($clientSecret, $grantType->clientSecret);
 
                 return new AccessToken('ABC123');
             });

--- a/tests/Auth/AccessTokenProvider/WithUsernameAndPasswordTest.php
+++ b/tests/Auth/AccessTokenProvider/WithUsernameAndPasswordTest.php
@@ -41,10 +41,10 @@ final class WithUsernameAndPasswordTest extends TestCase
         $accessTokenFetcher->expects($this->once())
             ->method('fetchAccessToken')
             ->with($this->isInstanceOf(PasswordGrantType::class))
-            ->willReturnCallback(function ($grantType) use ($username, $password) {
+            ->willReturnCallback(function ($grantType) use ($username, $password): AccessToken {
                 $this->assertInstanceOf(PasswordGrantType::class, $grantType);
-                $this->assertEquals($username, $grantType->username);
-                $this->assertEquals($password, $grantType->password);
+                $this->assertSame($username, $grantType->username);
+                $this->assertSame($password, $grantType->password);
 
                 return new AccessToken('ABC123');
             });

--- a/tests/Auth/GrantType/ClientCredentialsGrantTypeTest.php
+++ b/tests/Auth/GrantType/ClientCredentialsGrantTypeTest.php
@@ -46,7 +46,7 @@ final class ClientCredentialsGrantTypeTest extends TestCase
     {
         $grantType = new ClientCredentialsGrantType($clientId, $clientSecret);
         $this->assertInstanceOf(ClientCredentialsGrantType::class, $grantType);
-        $this->assertEquals($clientId, $grantType->clientId);
-        $this->assertEquals($clientSecret, $grantType->clientSecret);
+        $this->assertSame($clientId, $grantType->clientId);
+        $this->assertSame($clientSecret, $grantType->clientSecret);
     }
 }

--- a/tests/Auth/GrantType/PasswordGrantTypeTest.php
+++ b/tests/Auth/GrantType/PasswordGrantTypeTest.php
@@ -48,8 +48,8 @@ final class PasswordGrantTypeTest extends TestCase
     {
         $grantType = new PasswordGrantType($username, $password);
         $this->assertInstanceOf(PasswordGrantType::class, $grantType);
-        $this->assertEquals('administration', $grantType->clientId);
-        $this->assertEquals($username, $grantType->username);
-        $this->assertEquals($password, $grantType->password);
+        $this->assertSame('administration', $grantType->clientId);
+        $this->assertSame($username, $grantType->username);
+        $this->assertSame($password, $grantType->password);
     }
 }

--- a/tests/Auth/GrantType/RefreshTokenGrantTypeTest.php
+++ b/tests/Auth/GrantType/RefreshTokenGrantTypeTest.php
@@ -45,6 +45,6 @@ final class RefreshTokenGrantTypeTest extends TestCase
     {
         $grantType = new RefreshTokenGrantType($refreshToken);
         $this->assertInstanceOf(RefreshTokenGrantType::class, $grantType);
-        $this->assertEquals($refreshToken, $grantType->refreshToken);
+        $this->assertSame($refreshToken, $grantType->refreshToken);
     }
 }

--- a/tests/Context/ContextBuilderTest.php
+++ b/tests/Context/ContextBuilderTest.php
@@ -146,7 +146,7 @@ final class ContextBuilderTest extends TestCase
             $contextBuilder = $contextBuilder->withVersionId($versionId);
         }
 
-        if (is_array($additionalHeaders) && $addAdditionalHeadersOneByOne === true) {
+        if (is_array($additionalHeaders) && $addAdditionalHeadersOneByOne) {
             foreach ($additionalHeaders as $header => $value) {
                 $contextBuilder = $contextBuilder->withAdditionalHeader($header, $value);
             }
@@ -159,9 +159,9 @@ final class ContextBuilderTest extends TestCase
         $contextBuilder = $contextBuilder->build();
         $this->assertInstanceOf(Context::class, $contextBuilder);
         $this->assertEquals($expectedToken, $contextBuilder->accessToken);
-        $this->assertEquals($expectedLanguageId, $contextBuilder->languageId);
-        $this->assertEquals($expectedCurrencyId, $contextBuilder->currencyId);
-        $this->assertEquals($expectedVersionId, $contextBuilder->versionId);
+        $this->assertSame($expectedLanguageId, $contextBuilder->languageId);
+        $this->assertSame($expectedCurrencyId, $contextBuilder->currencyId);
+        $this->assertSame($expectedVersionId, $contextBuilder->versionId);
         $this->assertEquals($expectedCompatibility, $contextBuilder->compatibility);
         $this->assertEquals($expectedInheritance, $contextBuilder->inheritance);
         $this->assertEquals($expectedAdditionalHeaders, $contextBuilder->additionalHeaders);

--- a/tests/Data/CriteriaTest.php
+++ b/tests/Data/CriteriaTest.php
@@ -82,6 +82,7 @@ class CriteriaTest extends TestCase
         $criteria->addFilter(new PrefixFilter('title', 'awesome'));
         $criteria->addFilter(new SuffixFilter('description', 'bronze'));
         $criteria->setTotalCountMode(Criteria::TOTAL_COUNT_MODE_EXACT);
+
         $parsed = $criteria->parse();
 
         $expectedParsed = [
@@ -267,6 +268,6 @@ class CriteriaTest extends TestCase
             'total-count-mode' => 1,
         ];
 
-        static::assertEquals($parsed, $expectedParsed);
+        $this->assertEquals($parsed, $expectedParsed);
     }
 }

--- a/tests/Data/Response/ActionButtonResponseTest.php
+++ b/tests/Data/Response/ActionButtonResponseTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Vin\ShopwareSdkTest\Data\Response;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Vin\ShopwareSdk\Data\Response\ActionButtonResponse;
@@ -13,107 +14,105 @@ use Vin\ShopwareSdk\Data\Response\OpenModalResponse;
 use Vin\ShopwareSdk\Data\Response\OpenNewTabResponse;
 use Vin\ShopwareSdk\Data\Response\ReloadDataResponse;
 
-/**
- * @covers \Vin\ShopwareSdk\Data\Response\ActionButtonResponse
- */
+#[CoversClass(\Vin\ShopwareSdk\Data\Response\ActionButtonResponse::class)]
 class ActionButtonResponseTest extends TestCase
 {
     public function testEmptyResponsestEmptyResponse(): void
     {
         $response = new EmptyResponse();
 
-        static::assertEquals(0, $response->getBody()->getSize());
-        static::assertEmpty($response->getBody()->getContents());
-        static::assertEmpty($response->getHeaders());
-        static::assertEquals(204, $response->getStatusCode());
+        $this->assertSame(0, $response->getBody()->getSize());
+        $this->assertEmpty($response->getBody()->getContents());
+        $this->assertEmpty($response->getHeaders());
+        $this->assertSame(204, $response->getStatusCode());
     }
 
     public function testNotificationResponse(): void
     {
         $appSecret = 'appSecret';
         $response = new NotificationResponse('appSecret', 'Success', 'error');
-        static::assertInstanceOf(ResponseInterface::class, $response);
+        $this->assertInstanceOf(ResponseInterface::class, $response);
 
         $stringResponse = $response->getBody()
             ->__toString();
         $jsonResponse = json_decode($stringResponse, true);
         $signature = hash_hmac('sha256', $stringResponse, $appSecret);
 
-        static::assertNotEmpty($jsonResponse);
-        static::assertNotEmpty($response->getHeaders());
-        static::assertNotEmpty($response->getHeader('shopware-app-signature'));
-        static::assertEquals($signature, $response->getHeader('shopware-app-signature')[0]);
-        static::assertEquals(ActionButtonResponse::ACTION_SHOW_NOTIFICATION, $jsonResponse['actionType']);
-        static::assertEquals([
+        $this->assertNotEmpty($jsonResponse);
+        $this->assertNotEmpty($response->getHeaders());
+        $this->assertNotEmpty($response->getHeader('shopware-app-signature'));
+        $this->assertSame($signature, $response->getHeader('shopware-app-signature')[0]);
+        $this->assertSame(ActionButtonResponse::ACTION_SHOW_NOTIFICATION, $jsonResponse['actionType']);
+        $this->assertSame([
             'status' => 'error',
             'message' => 'Success',
         ], $jsonResponse['payload']);
-        static::assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     public function testReloadDataResponse(): void
     {
         $appSecret = 'appSecret';
         $response = new ReloadDataResponse('appSecret');
-        static::assertInstanceOf(ResponseInterface::class, $response);
+        $this->assertInstanceOf(ResponseInterface::class, $response);
 
         $stringResponse = $response->getBody()
             ->__toString();
         $jsonResponse = json_decode($stringResponse, true);
         $signature = hash_hmac('sha256', $stringResponse, $appSecret);
 
-        static::assertNotEmpty($jsonResponse);
-        static::assertNotEmpty($response->getHeaders());
-        static::assertNotEmpty($response->getHeader('shopware-app-signature'));
-        static::assertEquals($signature, $response->getHeader('shopware-app-signature')[0]);
-        static::assertEquals(ActionButtonResponse::ACTION_RELOAD_DATA, $jsonResponse['actionType']);
-        static::assertEquals([], $jsonResponse['payload']);
-        static::assertEquals(200, $response->getStatusCode());
+        $this->assertNotEmpty($jsonResponse);
+        $this->assertNotEmpty($response->getHeaders());
+        $this->assertNotEmpty($response->getHeader('shopware-app-signature'));
+        $this->assertSame($signature, $response->getHeader('shopware-app-signature')[0]);
+        $this->assertSame(ActionButtonResponse::ACTION_RELOAD_DATA, $jsonResponse['actionType']);
+        $this->assertSame([], $jsonResponse['payload']);
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     public function testOpenModalResponse(): void
     {
         $appSecret = 'appSecret';
         $response = new OpenModalResponse('appSecret', 'http://shopware.test');
-        static::assertInstanceOf(ResponseInterface::class, $response);
+        $this->assertInstanceOf(ResponseInterface::class, $response);
 
         $stringResponse = $response->getBody()
             ->__toString();
         $jsonResponse = json_decode($stringResponse, true);
         $signature = hash_hmac('sha256', $stringResponse, $appSecret);
 
-        static::assertNotEmpty($jsonResponse);
-        static::assertNotEmpty($response->getHeaders());
-        static::assertNotEmpty($response->getHeader('shopware-app-signature'));
-        static::assertEquals($signature, $response->getHeader('shopware-app-signature')[0]);
-        static::assertEquals(ActionButtonResponse::ACTION_OPEN_MODAL, $jsonResponse['actionType']);
-        static::assertEquals([
+        $this->assertNotEmpty($jsonResponse);
+        $this->assertNotEmpty($response->getHeaders());
+        $this->assertNotEmpty($response->getHeader('shopware-app-signature'));
+        $this->assertSame($signature, $response->getHeader('shopware-app-signature')[0]);
+        $this->assertSame(ActionButtonResponse::ACTION_OPEN_MODAL, $jsonResponse['actionType']);
+        $this->assertEquals([
             'iframeUrl' => 'http://shopware.test',
             'size' => OpenModalResponse::LARGE_SIZE,
             'expand' => false,
         ], $jsonResponse['payload']);
-        static::assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     public function testOpenNewTabResponse(): void
     {
         $appSecret = 'appSecret';
         $response = new OpenNewTabResponse('appSecret', 'https://google.com');
-        static::assertInstanceOf(ResponseInterface::class, $response);
+        $this->assertInstanceOf(ResponseInterface::class, $response);
 
         $stringResponse = $response->getBody()
             ->__toString();
         $jsonResponse = json_decode($stringResponse, true);
         $signature = hash_hmac('sha256', $stringResponse, $appSecret);
 
-        static::assertNotEmpty($jsonResponse);
-        static::assertNotEmpty($response->getHeaders());
-        static::assertNotEmpty($response->getHeader('shopware-app-signature'));
-        static::assertEquals($signature, $response->getHeader('shopware-app-signature')[0]);
-        static::assertEquals(ActionButtonResponse::ACTION_OPEN_NEW_TAB, $jsonResponse['actionType']);
-        static::assertEquals([
+        $this->assertNotEmpty($jsonResponse);
+        $this->assertNotEmpty($response->getHeaders());
+        $this->assertNotEmpty($response->getHeader('shopware-app-signature'));
+        $this->assertSame($signature, $response->getHeader('shopware-app-signature')[0]);
+        $this->assertSame(ActionButtonResponse::ACTION_OPEN_NEW_TAB, $jsonResponse['actionType']);
+        $this->assertSame([
             'redirectUrl' => 'https://google.com',
         ], $jsonResponse['payload']);
-        static::assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
     }
 }

--- a/tests/Data/Response/ActionButtonResponseTest.php
+++ b/tests/Data/Response/ActionButtonResponseTest.php
@@ -14,7 +14,7 @@ use Vin\ShopwareSdk\Data\Response\OpenModalResponse;
 use Vin\ShopwareSdk\Data\Response\OpenNewTabResponse;
 use Vin\ShopwareSdk\Data\Response\ReloadDataResponse;
 
-#[CoversClass(\Vin\ShopwareSdk\Data\Response\ActionButtonResponse::class)]
+#[CoversClass(ActionButtonResponse::class)]
 class ActionButtonResponseTest extends TestCase
 {
     public function testEmptyResponsestEmptyResponse(): void

--- a/tests/Data/Response/RegistrationResponseTest.php
+++ b/tests/Data/Response/RegistrationResponseTest.php
@@ -11,7 +11,7 @@ use Vin\ShopwareSdk\Data\Response\RegistrationResponse;
 use Vin\ShopwareSdk\Data\Webhook\Shop;
 use Vin\ShopwareSdk\Data\Webhook\ShopRegistrationResult;
 
-#[CoversClass(\Vin\ShopwareSdk\Data\Response\RegistrationResponse::class)]
+#[CoversClass(RegistrationResponse::class)]
 class RegistrationResponseTest extends TestCase
 {
     public function testResponse(): void

--- a/tests/Data/Response/RegistrationResponseTest.php
+++ b/tests/Data/Response/RegistrationResponseTest.php
@@ -4,15 +4,14 @@ declare(strict_types=1);
 
 namespace Vin\ShopwareSdkTest\Data\Response;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Vin\ShopwareSdk\Data\Response\RegistrationResponse;
 use Vin\ShopwareSdk\Data\Webhook\Shop;
 use Vin\ShopwareSdk\Data\Webhook\ShopRegistrationResult;
 
-/**
- * @covers \Vin\ShopwareSdk\Data\Response\RegistrationResponse
- */
+#[CoversClass(\Vin\ShopwareSdk\Data\Response\RegistrationResponse::class)]
 class RegistrationResponseTest extends TestCase
 {
     public function testResponse(): void
@@ -24,15 +23,15 @@ class RegistrationResponseTest extends TestCase
         $confirmationUrl = 'http://app.test/confirmation-url';
         $response = new RegistrationResponse($result, $confirmationUrl);
 
-        static::assertInstanceOf(ResponseInterface::class, $response);
+        $this->assertInstanceOf(ResponseInterface::class, $response);
         $jsonResponse = json_decode($response->getBody()->__toString(), true);
 
-        static::assertNotEmpty($jsonResponse);
-        static::assertEquals([
+        $this->assertNotEmpty($jsonResponse);
+        $this->assertSame([
             'proof' => $proof,
             'secret' => $shop->getShopSecret(),
             'confirmation_url' => $confirmationUrl,
         ], $jsonResponse);
-        static::assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
     }
 }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -91,8 +91,8 @@ final class HttpClientTest extends TestCase
         $returnedResponse = $httpClient->$serviceMethodName($path, $contentTypeHeader, $acceptHeader, $context);
         $this->assertInstanceOf(ApiResponse::class, $returnedResponse);
         $this->assertEquals($data, $returnedResponse->getContents());
-        $this->assertEquals([], $returnedResponse->getHeaders());
-        $this->assertEquals($statusCode, $returnedResponse->getStatusCode());
+        $this->assertSame([], $returnedResponse->getHeaders());
+        $this->assertSame($statusCode, $returnedResponse->getStatusCode());
     }
 
     #[DataProvider('deleteAndGetProvider')]
@@ -137,8 +137,8 @@ final class HttpClientTest extends TestCase
         $returnedResponse = $httpClient->$serviceMethodName($path, $contentTypeHeader, $acceptHeader, $requestData, $context);
         $this->assertInstanceOf(ApiResponse::class, $returnedResponse);
         $this->assertEquals($responseData, $returnedResponse->getContents());
-        $this->assertEquals([], $returnedResponse->getHeaders());
-        $this->assertEquals(200, $returnedResponse->getStatusCode());
+        $this->assertSame([], $returnedResponse->getHeaders());
+        $this->assertSame(200, $returnedResponse->getStatusCode());
     }
 
     #[DataProvider('patchAndPostProvider')]
@@ -182,8 +182,8 @@ final class HttpClientTest extends TestCase
         $returnedResponse = $httpClient->postGenericData($path, $contentTypeHeader, $acceptHeader, $requestData, $context);
         $this->assertInstanceOf(ApiResponse::class, $returnedResponse);
         $this->assertEquals($responseData, $returnedResponse->getContents());
-        $this->assertEquals([], $returnedResponse->getHeaders());
-        $this->assertEquals(200, $returnedResponse->getStatusCode());
+        $this->assertSame([], $returnedResponse->getHeaders());
+        $this->assertSame(200, $returnedResponse->getStatusCode());
     }
 
     #[DataProvider('postGenericDataProvider')]
@@ -229,9 +229,9 @@ final class HttpClientTest extends TestCase
     ): void {
         $requestFactory->expects($this->once())
             ->method('createRequest')
-            ->willReturnCallback(function ($passedMethod, $passedPath, $passedContentTypeHeader, $passedAcceptHeader, $passedContext) use ($method, $path, $contentTypeHeader, $acceptHeader, $context, $request) {
-                $this->assertEquals($method, $passedMethod);
-                $this->assertEquals($path, $passedPath);
+            ->willReturnCallback(function ($passedMethod, $passedPath, $passedContentTypeHeader, $passedAcceptHeader, $passedContext) use ($method, $path, $contentTypeHeader, $acceptHeader, $context, $request): RequestInterface {
+                $this->assertSame($method, $passedMethod);
+                $this->assertSame($path, $passedPath);
                 $this->assertEquals($contentTypeHeader, $passedContentTypeHeader);
                 $this->assertEquals($acceptHeader, $passedAcceptHeader);
                 $this->assertEquals($context, $passedContext);
@@ -252,9 +252,9 @@ final class HttpClientTest extends TestCase
     ): void {
         $requestFactory->expects($this->once())
             ->method('createRequestWithData')
-            ->willReturnCallback(function ($passedMethod, $passedPath, $passedContentTypeHeader, $passedAcceptHeader, $passedData, $passedContext) use ($method, $path, $contentTypeHeader, $acceptHeader, $data, $context, $request) {
-                $this->assertEquals($method, $passedMethod);
-                $this->assertEquals($path, $passedPath);
+            ->willReturnCallback(function ($passedMethod, $passedPath, $passedContentTypeHeader, $passedAcceptHeader, $passedData, $passedContext) use ($method, $path, $contentTypeHeader, $acceptHeader, $data, $context, $request): RequestInterface {
+                $this->assertSame($method, $passedMethod);
+                $this->assertSame($path, $passedPath);
                 $this->assertEquals($contentTypeHeader, $passedContentTypeHeader);
                 $this->assertEquals($acceptHeader, $passedAcceptHeader);
                 $this->assertEquals($data, $passedData);
@@ -276,12 +276,12 @@ final class HttpClientTest extends TestCase
     ): void {
         $requestFactory->expects($this->once())
             ->method('createRequestWithGenericData')
-            ->willReturnCallback(function ($passedMethod, $passedPath, $passedContentTypeHeader, $passedAcceptHeader, $passedData, $passedContext) use ($method, $path, $contentTypeHeader, $acceptHeader, $data, $context, $request) {
-                $this->assertEquals($method, $passedMethod);
-                $this->assertEquals($path, $passedPath);
+            ->willReturnCallback(function ($passedMethod, $passedPath, $passedContentTypeHeader, $passedAcceptHeader, $passedData, $passedContext) use ($method, $path, $contentTypeHeader, $acceptHeader, $data, $context, $request): RequestInterface {
+                $this->assertSame($method, $passedMethod);
+                $this->assertSame($path, $passedPath);
                 $this->assertEquals($contentTypeHeader, $passedContentTypeHeader);
                 $this->assertEquals($acceptHeader, $passedAcceptHeader);
-                $this->assertEquals($data, $passedData);
+                $this->assertSame($data, $passedData);
                 $this->assertEquals($context, $passedContext);
 
                 return $request;
@@ -292,7 +292,7 @@ final class HttpClientTest extends TestCase
     {
         $psrHttpClient->expects($this->once())
             ->method('sendRequest')
-            ->willReturnCallback(function ($passedRequest) use ($request, $response) {
+            ->willReturnCallback(function ($passedRequest) use ($request, $response): ResponseInterface {
                 $this->assertEquals($request, $passedRequest);
 
                 return $response;
@@ -310,7 +310,7 @@ final class HttpClientTest extends TestCase
     {
         $responseParser->expects($this->once())
             ->method('getDecodedResponseContent')
-            ->willReturnCallback(function ($passedResponse) use ($response, $data) {
+            ->willReturnCallback(function ($passedResponse) use ($response, $data): array {
                 $this->assertEquals($response, $passedResponse);
 
                 return $data;

--- a/tests/Http/RequestFactoryTest.php
+++ b/tests/Http/RequestFactoryTest.php
@@ -201,6 +201,7 @@ final class RequestFactoryTest extends TestCase
         if (is_string($data)) {
             $this->addCreateStreamMethodToStreamFactory($streamFactory, $data, $stream);
         }
+
         if (is_resource($data)) {
             $this->addCreateStreamFromResourceMethodToStreamFactory($streamFactory, $data, $stream);
         }
@@ -274,8 +275,8 @@ final class RequestFactoryTest extends TestCase
     {
         $psrRequestFactory->expects($this->once())
             ->method('createRequest')
-            ->willReturnCallback(function ($passedMethod, $passedUri) use ($method, $endpoint, $request) {
-                $this->assertEquals($method, $passedMethod);
+            ->willReturnCallback(function ($passedMethod, $passedUri) use ($method, $endpoint, $request): RequestInterface {
+                $this->assertSame($method, $passedMethod);
                 /** @phpstan-ignore-next-line */
                 $this->assertStringEndsWith($endpoint, $passedUri);
 
@@ -287,8 +288,8 @@ final class RequestFactoryTest extends TestCase
     {
         $streamFactory->expects($this->once())
             ->method('createStream')
-            ->willReturnCallback(function ($passedData) use ($data, $stream) {
-                $this->assertEquals($data, $passedData);
+            ->willReturnCallback(function ($passedData) use ($data, $stream): StreamInterface {
+                $this->assertSame($data, $passedData);
 
                 return $stream;
             });
@@ -301,7 +302,7 @@ final class RequestFactoryTest extends TestCase
     {
         $streamFactory->expects($this->once())
             ->method('createStreamFromResource')
-            ->willReturnCallback(function ($passedData) use ($data, $stream) {
+            ->willReturnCallback(function ($passedData) use ($data, $stream): StreamInterface {
                 $this->assertEquals($data, $passedData);
 
                 return $stream;
@@ -312,7 +313,7 @@ final class RequestFactoryTest extends TestCase
     {
         $request->expects($this->once())
             ->method('withBody')
-            ->willReturnCallback(function ($passedStream) use ($expectedStream, $request) {
+            ->willReturnCallback(function ($passedStream) use ($expectedStream, $request): MockObject {
                 $this->assertEquals($expectedStream, $passedStream);
 
                 return $request;
@@ -324,7 +325,7 @@ final class RequestFactoryTest extends TestCase
         $withHeaderMethodCall = 0;
         $request->expects($this->exactly(8))
             ->method('withHeader')
-            ->willReturnCallback(function (string $name, $value) use ($expectedHeaders, &$withHeaderMethodCall, $request) {
+            ->willReturnCallback(function (string $name, $value) use ($expectedHeaders, &$withHeaderMethodCall, $request): MockObject {
                 $this->assertEquals($expectedHeaders[$withHeaderMethodCall], [
                     $name => $value,
                 ]);

--- a/tests/Http/ResponseParserTest.php
+++ b/tests/Http/ResponseParserTest.php
@@ -120,6 +120,6 @@ final class ResponseParserTest extends TestCase
     public function testGetDecodedResponseContentWithBlankResponseContent(ResponseParser $responseParser, ResponseInterface $response): void
     {
         $decodedContent = $responseParser->getDecodedResponseContent($response);
-        $this->assertEquals([], $decodedContent);
+        $this->assertSame([], $decodedContent);
     }
 }

--- a/tests/Hydrate/EntityHydratorTest.php
+++ b/tests/Hydrate/EntityHydratorTest.php
@@ -41,11 +41,11 @@ class EntityHydratorTest extends TestCase
     {
         $result = $this->entityHydrator->hydrateSearchResult([]);
 
-        static::assertInstanceOf(EntityCollection::class, $result);
+        $this->assertInstanceOf(EntityCollection::class, $result);
 
         $result = $this->entityHydrator->hydrateSearchResult([], 'product');
 
-        static::assertInstanceOf(ProductCollection::class, $result);
+        $this->assertInstanceOf(ProductCollection::class, $result);
     }
 
     public function testHydrateSearchResultWithResult(): void
@@ -63,8 +63,8 @@ class EntityHydratorTest extends TestCase
             ],
         ], 'product');
 
-        static::assertInstanceOf(ProductCollection::class, $result);
-        static::assertCount(1, $result);
-        static::assertInstanceOf(ProductEntity::class, $result->get($productId));
+        $this->assertInstanceOf(ProductCollection::class, $result);
+        $this->assertCount(1, $result);
+        $this->assertInstanceOf(ProductEntity::class, $result->get($productId));
     }
 }

--- a/tests/Hydrate/Result/EntityExtensionResultTest.php
+++ b/tests/Hydrate/Result/EntityExtensionResultTest.php
@@ -30,7 +30,7 @@ final class EntityExtensionResultTest extends TestCase
     {
         $jsonData = self::parseStub('product');
         $productId = $jsonData['data'][0]['id'];
-        $data = $jsonData['included'][array_search($productId, array_column($jsonData['included'], 'id'))];
+        $data = $jsonData['included'][array_search($productId, array_column($jsonData['included'], 'id'), true)];
 
         yield [
             $data,
@@ -75,7 +75,7 @@ final class EntityExtensionResultTest extends TestCase
     ): void {
         /** @phpstan-ignore-next-line */
         $entityResult = EntityExtensionResult::fromData($data);
-        $this->assertEquals($expectedId, $entityResult->id);
+        $this->assertSame($expectedId, $entityResult->id);
     }
 
     #[DataProvider('hydrateExtensionProvider')]
@@ -93,6 +93,6 @@ final class EntityExtensionResultTest extends TestCase
         $this->assertInstanceOf(ProductMediaCollection::class, $entity->getExtension('additionalMedia'));
         /** @var ProductMediaCollection $additionalMedia */
         $additionalMedia = $entity->getExtension('additionalMedia');
-        $this->assertEquals(1, $additionalMedia->count());
+        $this->assertCount(1, $additionalMedia);
     }
 }

--- a/tests/Hydrate/Result/EntityResultRelationshipTest.php
+++ b/tests/Hydrate/Result/EntityResultRelationshipTest.php
@@ -53,8 +53,8 @@ final class EntityResultRelationshipTest extends TestCase
     ): void {
         $entityResultRelationship = $entityResultRelationshipClassName::fromDataAndPropertyName($data, $propertyName);
         $this->assertInstanceOf($entityResultRelationshipClassName, $entityResultRelationship);
-        $this->assertEquals($propertyName, $entityResultRelationship->propertyNameInEntity);
-        $this->assertEquals($expectedRelatedEntityName, $entityResultRelationship->relatedEntityName);
-        $this->assertEquals($expectedRelatedEntityId, $entityResultRelationship->relatedEntityId);
+        $this->assertSame($propertyName, $entityResultRelationship->propertyNameInEntity);
+        $this->assertSame($expectedRelatedEntityName, $entityResultRelationship->relatedEntityName);
+        $this->assertSame($expectedRelatedEntityId, $entityResultRelationship->relatedEntityId);
     }
 }

--- a/tests/Hydrate/Result/EntityResultTest.php
+++ b/tests/Hydrate/Result/EntityResultTest.php
@@ -103,7 +103,7 @@ final class EntityResultTest extends TestCase
         $entityResultCache = new EntityResultCache();
         self::populateEntityResultCache($entityResultCache, $jsonData['included']);
 
-        $productManufacturer = $jsonData['included'][array_search($data['attributes']['manufacturerId'], array_column($jsonData['included'], 'id'))] ?? null;
+        $productManufacturer = $jsonData['included'][array_search($data['attributes']['manufacturerId'], array_column($jsonData['included'], 'id'), true)] ?? null;
 
         yield [
             $entityResult,
@@ -130,10 +130,10 @@ final class EntityResultTest extends TestCase
     ): void {
         /** @phpstan-ignore-next-line */
         $entityResult = EntityResult::fromData($data);
-        $this->assertEquals($expectedId, $entityResult->id);
+        $this->assertSame($expectedId, $entityResult->id);
         $this->assertEquals($expectedAttributes, $entityResult->attributes);
         $this->assertEquals($expectedRelationships, $entityResult->relationships);
-        $this->assertEquals($expectedEntityName, $entityResult->entityName);
+        $this->assertSame($expectedEntityName, $entityResult->entityName);
     }
 
     #[DataProvider('getEntityProvider')]
@@ -148,8 +148,8 @@ final class EntityResultTest extends TestCase
         $entity = $entityResult->getEntity($attributeHydrator, $definitionProvider);
 
         $this->assertInstanceOf(Entity::class, $entity);
-        $this->assertEquals($expectedId, $entity->id);
-        $this->assertEquals($expectedProductNumber, $entity->productNumber);
+        $this->assertSame($expectedId, $entity->id);
+        $this->assertSame($expectedProductNumber, $entity->productNumber);
         $this->assertNull($entity->manufacturer);
     }
 
@@ -178,7 +178,7 @@ final class EntityResultTest extends TestCase
         $this->assertInstanceOf(ProductMediaCollection::class, $entity->getExtension('additionalMedia'));
         /** @var ProductMediaCollection $additionalMedia */
         $additionalMedia = $entity->getExtension('additionalMedia');
-        $this->assertEquals(1, $additionalMedia->count());
+        $this->assertCount(1, $additionalMedia);
     }
 
     #[DataProvider('hydrateRelationshipsProvider')]

--- a/tests/Hydrate/Result/EntityResultToManyRelationshipTest.php
+++ b/tests/Hydrate/Result/EntityResultToManyRelationshipTest.php
@@ -81,7 +81,7 @@ final class EntityResultToManyRelationshipTest extends TestCase
         );
 
         $this->assertInstanceOf(ProductMediaCollection::class, $entity->media);
-        $this->assertEquals(1, $entity->media->count());
-        $this->assertEquals($expectedProductMediaId, $entity->media->first()?->id);
+        $this->assertSame(1, $entity->media->count());
+        $this->assertSame($expectedProductMediaId, $entity->media->first()?->id);
     }
 }

--- a/tests/Hydrate/Result/EntityResultToOneRelationshipTest.php
+++ b/tests/Hydrate/Result/EntityResultToOneRelationshipTest.php
@@ -81,6 +81,6 @@ final class EntityResultToOneRelationshipTest extends TestCase
         );
 
         $this->assertInstanceOf(ProductManufacturerEntity::class, $entity->manufacturer);
-        $this->assertEquals($expectedProductManufacturerId, $entity->manufacturer->id);
+        $this->assertSame($expectedProductManufacturerId, $entity->manufacturer->id);
     }
 }

--- a/tests/Hydrate/Result/SearchResultTest.php
+++ b/tests/Hydrate/Result/SearchResultTest.php
@@ -63,13 +63,13 @@ final class SearchResultTest extends TestCase
             $productManufacturerId = $data['relationships']['manufacturer']['data']['id'] ?? null;
             $productManufacturer = null;
             if (is_string($productManufacturerId)) {
-                $productManufacturer = $jsonData['included'][array_search($productManufacturerId, array_column($jsonData['included'], 'id'))] ?? null;
+                $productManufacturer = $jsonData['included'][array_search($productManufacturerId, array_column($jsonData['included'], 'id'), true)] ?? null;
             }
 
             $taxId = $data['relationships']['tax']['data']['id'] ?? null;
             $tax = null;
             if (is_string($taxId)) {
-                $tax = $jsonData['included'][array_search($taxId, array_column($jsonData['included'], 'id'))] ?? null;
+                $tax = $jsonData['included'][array_search($taxId, array_column($jsonData['included'], 'id'), true)] ?? null;
             }
 
             yield 'product ' . $data['id'] => [
@@ -106,9 +106,7 @@ final class SearchResultTest extends TestCase
         );
 
         $this->assertCount($expectedEntityCount, $entities);
-        foreach ($entities as $entity) {
-            $this->assertInstanceOf(Entity::class, $entity);
-        }
+        $this->assertContainsOnlyInstancesOf(Entity::class, $entities);
 
         foreach ($expectedIds as $expectedId) {
             $this->assertArrayHasKey($expectedId, $entities);
@@ -142,8 +140,8 @@ final class SearchResultTest extends TestCase
         $entity = array_pop($entities);
 
         $this->assertInstanceOf(Entity::class, $entity);
-        $this->assertEquals($expectedId, $entity->id);
-        $this->assertEquals($expectedProductNumber, $entity->productNumber);
+        $this->assertSame($expectedId, $entity->id);
+        $this->assertSame($expectedProductNumber, $entity->productNumber);
 
         $this->assertEquals($expectedManufacturerId, $entity->manufacturerId);
         $this->assertEquals($expectedManufacturerName, $entity->manufacturer?->name);

--- a/tests/Hydrate/Service/RelationshipParserTest.php
+++ b/tests/Hydrate/Service/RelationshipParserTest.php
@@ -47,7 +47,7 @@ final class RelationshipParserTest extends TestCase
         ];
 
         $relationshipDatasets = array_merge($relationshipDatasets);
-        foreach ($relationshipDatasets as $key => $relationshipDataset) {
+        foreach (array_keys($relationshipDatasets) as $key) {
             $relationshipDatasets[$key]['data'] = null;
         }
 

--- a/tests/Hydrate/Service/RelationshipParserTest.php
+++ b/tests/Hydrate/Service/RelationshipParserTest.php
@@ -36,7 +36,7 @@ final class RelationshipParserTest extends TestCase
         ];
 
         $relationshipDatasets = array_merge($relationshipDatasets);
-        foreach ($relationshipDatasets as $key => $relationshipDataset) {
+        foreach (array_keys($relationshipDatasets) as $key) {
             unset($relationshipDatasets[$key]['data']);
         }
 

--- a/tests/Repository/EntityRepositoryTest.php
+++ b/tests/Repository/EntityRepositoryTest.php
@@ -74,7 +74,7 @@ final class EntityRepositoryTest extends TestCase
         $httpClient->expects($this->once())
             ->method('post')
             ->willReturnCallback(function (string $path, MediaType $contentTypeHeader, MediaType $acceptHeader, array $data, Context $context) use ($expectedPath, $expectedData, $expectedNewId): ApiResponse {
-                $this->assertEquals($expectedPath, $path);
+                $this->assertSame($expectedPath, $path);
                 $this->assertEquals(MediaType::APPLICATION_JSON, $contentTypeHeader);
                 $this->assertEquals(MediaType::APPLICATION_JSON_API, $acceptHeader);
                 $this->assertEquals($expectedData, $data);
@@ -91,7 +91,7 @@ final class EntityRepositoryTest extends TestCase
 
         $entityRepository = new EntityRepository($entityDefinition, $contextBuilderFactory, $httpClient, $hydrator);
 
-        $this->assertEquals($expectedNewId, $entityRepository->clone($id, $cloneBehaviour));
+        $this->assertSame($expectedNewId, $entityRepository->clone($id, $cloneBehaviour));
     }
 
     public static function createProvider(): \Generator
@@ -122,7 +122,7 @@ final class EntityRepositoryTest extends TestCase
         $httpClient->expects($this->once())
             ->method('post')
             ->willReturnCallback(function (string $path, MediaType $contentTypeHeader, MediaType $acceptHeader, array $data, Context $context) use ($expectedPath, $expectedData): ApiResponse {
-                $this->assertEquals($expectedPath, $path);
+                $this->assertSame($expectedPath, $path);
                 $this->assertEquals(MediaType::APPLICATION_JSON, $contentTypeHeader);
                 $this->assertEquals(MediaType::APPLICATION_JSON_API, $acceptHeader);
                 $this->assertEquals($expectedData, $data);
@@ -161,7 +161,7 @@ final class EntityRepositoryTest extends TestCase
             ->getEntityClass();
 
         $this->assertInstanceOf($expectedEntityClass, $entity);
-        $this->assertEquals($entityRepository->getDefinition()->getEntityName(), $entity->getEntityName());
+        $this->assertSame($entityRepository->getDefinition()->getEntityName(), $entity->getEntityName());
     }
 
     public static function createVersionProvider(): \Generator
@@ -224,15 +224,16 @@ final class EntityRepositoryTest extends TestCase
         $httpClient->expects($this->once())
             ->method('post')
             ->willReturnCallback(function (string $path, MediaType $contentTypeHeader, MediaType $acceptHeader, array $data, Context $context) use ($expectedPath, $versionId, $versionName, $expectedData): ApiResponse {
-                $this->assertEquals($expectedPath, $path);
+                $this->assertSame($expectedPath, $path);
                 $this->assertEquals(MediaType::APPLICATION_JSON, $contentTypeHeader);
                 $this->assertEquals(MediaType::APPLICATION_JSON_API, $acceptHeader);
 
                 if ($versionId !== null) {
-                    $this->assertEquals($versionId, $data['versionId']);
+                    $this->assertSame($versionId, $data['versionId']);
                 }
+
                 if ($versionName !== null) {
-                    $this->assertEquals($versionName, $data['versionName']);
+                    $this->assertSame($versionName, $data['versionName']);
                 }
 
                 $this->assertInstanceOf(Context::class, $context);
@@ -275,7 +276,7 @@ final class EntityRepositoryTest extends TestCase
         $httpClient->expects($this->once())
             ->method('delete')
             ->willReturnCallback(function (string $path, MediaType $contentTypeHeader, MediaType $acceptHeader, Context $context) use ($expectedPath): ApiResponse {
-                $this->assertEquals($expectedPath, $path);
+                $this->assertSame($expectedPath, $path);
                 $this->assertEquals(MediaType::APPLICATION_JSON, $contentTypeHeader);
                 $this->assertEquals(MediaType::APPLICATION_JSON_API, $acceptHeader);
                 $this->assertInstanceOf(Context::class, $context);
@@ -315,7 +316,7 @@ final class EntityRepositoryTest extends TestCase
         $httpClient->expects($this->once())
             ->method('post')
             ->willReturnCallback(function (string $path, MediaType $contentTypeHeader, MediaType $acceptHeader, array $data, Context $context) use ($expectedPath): ApiResponse {
-                $this->assertEquals($expectedPath, $path);
+                $this->assertSame($expectedPath, $path);
                 $this->assertEquals(MediaType::APPLICATION_JSON, $contentTypeHeader);
                 $this->assertEquals(MediaType::APPLICATION_JSON_API, $acceptHeader);
                 $this->assertEmpty($data);
@@ -351,10 +352,10 @@ final class EntityRepositoryTest extends TestCase
         $httpClient->expects($this->once())
             ->method('post')
             ->willReturnCallback(function (string $path, MediaType $contentTypeHeader, MediaType $acceptHeader, array $criteria, Context $context) use ($expectedPath, $id): ApiResponse {
-                $this->assertEquals($expectedPath, $path);
+                $this->assertSame($expectedPath, $path);
                 $this->assertEquals(MediaType::APPLICATION_JSON, $contentTypeHeader);
                 $this->assertEquals(MediaType::APPLICATION_JSON_API, $acceptHeader);
-                $this->assertEquals($id, $criteria['ids']);
+                $this->assertSame($id, $criteria['ids']);
                 $this->assertInstanceOf(Context::class, $context);
 
                 $response = $this->createStub(ApiResponse::class);
@@ -428,11 +429,11 @@ final class EntityRepositoryTest extends TestCase
         $httpClient->expects($this->once())
             ->method('post')
             ->willReturnCallback(function (string $path, MediaType $contentTypeHeader, MediaType $acceptHeader, array $data, Context $context) use ($versionId, $expectedPath): ApiResponse {
-                $this->assertEquals($expectedPath, $path);
+                $this->assertSame($expectedPath, $path);
                 $this->assertEquals(MediaType::APPLICATION_JSON, $contentTypeHeader);
                 $this->assertEquals(MediaType::APPLICATION_JSON_API, $acceptHeader);
                 $this->assertEmpty($data);
-                $this->assertEquals($versionId, $context->additionalHeaders['sw-version-id']);
+                $this->assertSame($versionId, $context->additionalHeaders['sw-version-id']);
 
                 return $this->createStub(ApiResponse::class);
             });
@@ -467,7 +468,7 @@ final class EntityRepositoryTest extends TestCase
         $httpClient->expects($this->once())
             ->method('post')
             ->willReturnCallback(function (string $path, MediaType $contentTypeHeader, MediaType $acceptHeader, array $data, Context $context) use ($criteria, $expectedPath): ApiResponse {
-                $this->assertEquals($expectedPath, $path);
+                $this->assertSame($expectedPath, $path);
                 $this->assertEquals(MediaType::APPLICATION_JSON, $contentTypeHeader);
                 $this->assertEquals(MediaType::APPLICATION_JSON_API, $acceptHeader);
                 $this->assertEquals($criteria->parse(), $data);
@@ -517,7 +518,7 @@ final class EntityRepositoryTest extends TestCase
         $httpClient->expects($this->once())
             ->method('post')
             ->willReturnCallback(function (string $path, MediaType $contentTypeHeader, MediaType $acceptHeader, array $data, Context $context) use ($criteria, $expectedPath): ApiResponse {
-                $this->assertEquals($expectedPath, $path);
+                $this->assertSame($expectedPath, $path);
                 $this->assertEquals(MediaType::APPLICATION_JSON, $contentTypeHeader);
                 $this->assertEquals(MediaType::APPLICATION_JSON_API, $acceptHeader);
                 $this->assertEquals($criteria->parse(), $data);
@@ -567,7 +568,7 @@ final class EntityRepositoryTest extends TestCase
         $httpClient->expects($this->once())
             ->method('patch')
             ->willReturnCallback(function (string $path, MediaType $contentTypeHeader, MediaType $acceptHeader, array $data, Context $context) use ($expectedPath, $expectedData): ApiResponse {
-                $this->assertEquals($expectedPath, $path);
+                $this->assertSame($expectedPath, $path);
                 $this->assertEquals(MediaType::APPLICATION_JSON, $contentTypeHeader);
                 $this->assertEquals(MediaType::APPLICATION_JSON_API, $acceptHeader);
                 $this->assertEquals($expectedData, $data);

--- a/tests/Repository/EntityRepositoryTest.php
+++ b/tests/Repository/EntityRepositoryTest.php
@@ -75,8 +75,8 @@ final class EntityRepositoryTest extends TestCase
             ->method('post')
             ->willReturnCallback(function (string $path, MediaType $contentTypeHeader, MediaType $acceptHeader, array $data, Context $context) use ($expectedPath, $expectedData, $expectedNewId): ApiResponse {
                 $this->assertSame($expectedPath, $path);
-                $this->assertEquals(MediaType::APPLICATION_JSON, $contentTypeHeader);
-                $this->assertEquals(MediaType::APPLICATION_JSON_API, $acceptHeader);
+                $this->assertSame(MediaType::APPLICATION_JSON, $contentTypeHeader);
+                $this->assertSame(MediaType::APPLICATION_JSON_API, $acceptHeader);
                 $this->assertEquals($expectedData, $data);
                 $this->assertInstanceOf(Context::class, $context);
 
@@ -123,8 +123,8 @@ final class EntityRepositoryTest extends TestCase
             ->method('post')
             ->willReturnCallback(function (string $path, MediaType $contentTypeHeader, MediaType $acceptHeader, array $data, Context $context) use ($expectedPath, $expectedData): ApiResponse {
                 $this->assertSame($expectedPath, $path);
-                $this->assertEquals(MediaType::APPLICATION_JSON, $contentTypeHeader);
-                $this->assertEquals(MediaType::APPLICATION_JSON_API, $acceptHeader);
+                $this->assertSame(MediaType::APPLICATION_JSON, $contentTypeHeader);
+                $this->assertSame(MediaType::APPLICATION_JSON_API, $acceptHeader);
                 $this->assertEquals($expectedData, $data);
                 $this->assertInstanceOf(Context::class, $context);
 
@@ -225,8 +225,8 @@ final class EntityRepositoryTest extends TestCase
             ->method('post')
             ->willReturnCallback(function (string $path, MediaType $contentTypeHeader, MediaType $acceptHeader, array $data, Context $context) use ($expectedPath, $versionId, $versionName, $expectedData): ApiResponse {
                 $this->assertSame($expectedPath, $path);
-                $this->assertEquals(MediaType::APPLICATION_JSON, $contentTypeHeader);
-                $this->assertEquals(MediaType::APPLICATION_JSON_API, $acceptHeader);
+                $this->assertSame(MediaType::APPLICATION_JSON, $contentTypeHeader);
+                $this->assertSame(MediaType::APPLICATION_JSON_API, $acceptHeader);
 
                 if ($versionId !== null) {
                     $this->assertSame($versionId, $data['versionId']);
@@ -277,8 +277,8 @@ final class EntityRepositoryTest extends TestCase
             ->method('delete')
             ->willReturnCallback(function (string $path, MediaType $contentTypeHeader, MediaType $acceptHeader, Context $context) use ($expectedPath): ApiResponse {
                 $this->assertSame($expectedPath, $path);
-                $this->assertEquals(MediaType::APPLICATION_JSON, $contentTypeHeader);
-                $this->assertEquals(MediaType::APPLICATION_JSON_API, $acceptHeader);
+                $this->assertSame(MediaType::APPLICATION_JSON, $contentTypeHeader);
+                $this->assertSame(MediaType::APPLICATION_JSON_API, $acceptHeader);
                 $this->assertInstanceOf(Context::class, $context);
 
                 return $this->createStub(ApiResponse::class);
@@ -317,8 +317,8 @@ final class EntityRepositoryTest extends TestCase
             ->method('post')
             ->willReturnCallback(function (string $path, MediaType $contentTypeHeader, MediaType $acceptHeader, array $data, Context $context) use ($expectedPath): ApiResponse {
                 $this->assertSame($expectedPath, $path);
-                $this->assertEquals(MediaType::APPLICATION_JSON, $contentTypeHeader);
-                $this->assertEquals(MediaType::APPLICATION_JSON_API, $acceptHeader);
+                $this->assertSame(MediaType::APPLICATION_JSON, $contentTypeHeader);
+                $this->assertSame(MediaType::APPLICATION_JSON_API, $acceptHeader);
                 $this->assertEmpty($data);
                 $this->assertInstanceOf(Context::class, $context);
 
@@ -353,8 +353,8 @@ final class EntityRepositoryTest extends TestCase
             ->method('post')
             ->willReturnCallback(function (string $path, MediaType $contentTypeHeader, MediaType $acceptHeader, array $criteria, Context $context) use ($expectedPath, $id): ApiResponse {
                 $this->assertSame($expectedPath, $path);
-                $this->assertEquals(MediaType::APPLICATION_JSON, $contentTypeHeader);
-                $this->assertEquals(MediaType::APPLICATION_JSON_API, $acceptHeader);
+                $this->assertSame(MediaType::APPLICATION_JSON, $contentTypeHeader);
+                $this->assertSame(MediaType::APPLICATION_JSON_API, $acceptHeader);
                 $this->assertSame($id, $criteria['ids']);
                 $this->assertInstanceOf(Context::class, $context);
 
@@ -430,8 +430,8 @@ final class EntityRepositoryTest extends TestCase
             ->method('post')
             ->willReturnCallback(function (string $path, MediaType $contentTypeHeader, MediaType $acceptHeader, array $data, Context $context) use ($versionId, $expectedPath): ApiResponse {
                 $this->assertSame($expectedPath, $path);
-                $this->assertEquals(MediaType::APPLICATION_JSON, $contentTypeHeader);
-                $this->assertEquals(MediaType::APPLICATION_JSON_API, $acceptHeader);
+                $this->assertSame(MediaType::APPLICATION_JSON, $contentTypeHeader);
+                $this->assertSame(MediaType::APPLICATION_JSON_API, $acceptHeader);
                 $this->assertEmpty($data);
                 $this->assertSame($versionId, $context->additionalHeaders['sw-version-id']);
 
@@ -469,8 +469,8 @@ final class EntityRepositoryTest extends TestCase
             ->method('post')
             ->willReturnCallback(function (string $path, MediaType $contentTypeHeader, MediaType $acceptHeader, array $data, Context $context) use ($criteria, $expectedPath): ApiResponse {
                 $this->assertSame($expectedPath, $path);
-                $this->assertEquals(MediaType::APPLICATION_JSON, $contentTypeHeader);
-                $this->assertEquals(MediaType::APPLICATION_JSON_API, $acceptHeader);
+                $this->assertSame(MediaType::APPLICATION_JSON, $contentTypeHeader);
+                $this->assertSame(MediaType::APPLICATION_JSON_API, $acceptHeader);
                 $this->assertEquals($criteria->parse(), $data);
                 $this->assertInstanceOf(Context::class, $context);
 
@@ -519,8 +519,8 @@ final class EntityRepositoryTest extends TestCase
             ->method('post')
             ->willReturnCallback(function (string $path, MediaType $contentTypeHeader, MediaType $acceptHeader, array $data, Context $context) use ($criteria, $expectedPath): ApiResponse {
                 $this->assertSame($expectedPath, $path);
-                $this->assertEquals(MediaType::APPLICATION_JSON, $contentTypeHeader);
-                $this->assertEquals(MediaType::APPLICATION_JSON_API, $acceptHeader);
+                $this->assertSame(MediaType::APPLICATION_JSON, $contentTypeHeader);
+                $this->assertSame(MediaType::APPLICATION_JSON_API, $acceptHeader);
                 $this->assertEquals($criteria->parse(), $data);
                 $this->assertInstanceOf(Context::class, $context);
 
@@ -569,8 +569,8 @@ final class EntityRepositoryTest extends TestCase
             ->method('patch')
             ->willReturnCallback(function (string $path, MediaType $contentTypeHeader, MediaType $acceptHeader, array $data, Context $context) use ($expectedPath, $expectedData): ApiResponse {
                 $this->assertSame($expectedPath, $path);
-                $this->assertEquals(MediaType::APPLICATION_JSON, $contentTypeHeader);
-                $this->assertEquals(MediaType::APPLICATION_JSON_API, $acceptHeader);
+                $this->assertSame(MediaType::APPLICATION_JSON, $contentTypeHeader);
+                $this->assertSame(MediaType::APPLICATION_JSON_API, $acceptHeader);
                 $this->assertEquals($expectedData, $data);
                 $this->assertInstanceOf(Context::class, $context);
 

--- a/tests/Repository/RepositoryProviderTest.php
+++ b/tests/Repository/RepositoryProviderTest.php
@@ -35,8 +35,8 @@ final class RepositoryProviderTest extends TestCase
         $definitionProvider = $this->createMock(DefinitionProviderInterface::class);
         $definitionProvider->expects($this->once())
             ->method('getDefinition')
-            ->willReturnCallback(function (string $entityName) {
-                $this->assertEquals(ProductDefinition::ENTITY_NAME, $entityName);
+            ->willReturnCallback(function (string $entityName): ProductDefinition {
+                $this->assertSame(ProductDefinition::ENTITY_NAME, $entityName);
 
                 return new ProductDefinition();
             });
@@ -44,7 +44,7 @@ final class RepositoryProviderTest extends TestCase
         $repositoryProvider = new RepositoryProvider($definitionProvider, $contextBuilderFactory, $httpClient, $entityHydrator);
 
         $entityRepository = $repositoryProvider->getRepository($entityName);
-        $this->assertEquals($entityName, $entityRepository->getDefinition()->getEntityName());
+        $this->assertSame($entityName, $entityRepository->getDefinition()->getEntityName());
 
         $alreadyInitializedEntityRepository = $repositoryProvider->getRepository($entityName);
         $this->assertSame($entityRepository, $alreadyInitializedEntityRepository);


### PR DESCRIPTION
The PHP rector rules were extended and the new rules were applicated to all code except the auto-generated entities.