### PR TITLE
Drop PHP 8.1 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: [ '8.1' ]
+        php-versions: [ '8.2' ]
     steps:
       - name: Check out the repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: [ '8.1' ]
+        php-versions: [ '8.2' ]
     steps:
       - name: Check out the repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -88,7 +88,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: [ '8.1' ]
+        php-versions: [ '8.2' ]
     steps:
       - name: Check out the repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -120,11 +120,11 @@ jobs:
 
   unit-tests:
     name: Unit tests
-    runs-on: 'ubuntu-latest'
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        php-versions: [ '8.1', '8.2', '8.3' ]
+        php-versions: [ '8.2', '8.3' ]
     steps:
       - name: Check out the repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "vin-sw/shopware-sdk": "*"
     },
     "require": {
-        "php": "^8.1 || ^8.2 || ^8.3",
+        "php": "^8.2 || ^8.3",
         "ext-json": "*",
         "psr/clock": "^1.0",
         "psr/http-client": "^1.0",

--- a/rector.php
+++ b/rector.php
@@ -11,7 +11,7 @@ return RectorConfig::configure()
         __DIR__ . '/src',
         __DIR__ . '/tests',
     ])
-    ->withSets([LevelSetList::UP_TO_PHP_81])
+    ->withSets([LevelSetList::UP_TO_PHP_82])
     ->withCache(
         cacheDirectory: '/tmp/rector',
         cacheClass: FileCacheStorage::class

--- a/src/Auth/AccessTokenFetcher/CachedFetcher.php
+++ b/src/Auth/AccessTokenFetcher/CachedFetcher.php
@@ -12,12 +12,12 @@ use Vin\ShopwareSdk\Auth\GrantType;
 use Vin\ShopwareSdk\Data\AccessToken;
 use Vin\ShopwareSdk\Exception\AuthorizationFailedException;
 
-final class CachedFetcher implements AccessTokenFetcher
+final readonly class CachedFetcher implements AccessTokenFetcher
 {
     public function __construct(
-        private readonly AccessTokenFetcher $accessTokenFetcher,
-        private readonly CacheInterface $cache,
-        private readonly ClockInterface $clock
+        private AccessTokenFetcher $accessTokenFetcher,
+        private CacheInterface $cache,
+        private ClockInterface $clock
     ) {
     }
 

--- a/src/Auth/AccessTokenFetcher/SimpleFetcher.php
+++ b/src/Auth/AccessTokenFetcher/SimpleFetcher.php
@@ -13,15 +13,15 @@ use Vin\ShopwareSdk\Exception\AuthorizationFailedException;
 use Vin\ShopwareSdk\Exception\ShopwareResponseException;
 use Vin\ShopwareSdk\Http\ResponseParserInterface;
 
-final class SimpleFetcher implements AccessTokenFetcher
+final readonly class SimpleFetcher implements AccessTokenFetcher
 {
     private const OAUTH_TOKEN_ENDPOINT = '/api/oauth/token';
 
     public function __construct(
-        private readonly string $shopUrl,
-        private readonly TokenRequestFactoryInterface $tokenRequestFactory,
-        private readonly ResponseParserInterface $responseParser,
-        private readonly ClientInterface $psr18HttpClient,
+        private string $shopUrl,
+        private TokenRequestFactoryInterface $tokenRequestFactory,
+        private ResponseParserInterface $responseParser,
+        private ClientInterface $psr18HttpClient,
     ) {
     }
 

--- a/src/Auth/AccessTokenFetcher/TokenRequestFactory.php
+++ b/src/Auth/AccessTokenFetcher/TokenRequestFactory.php
@@ -8,11 +8,11 @@ use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 
-final class TokenRequestFactory implements TokenRequestFactoryInterface
+final readonly class TokenRequestFactory implements TokenRequestFactoryInterface
 {
     public function __construct(
-        private readonly StreamFactoryInterface $streamFactory,
-        private readonly RequestFactoryInterface $requestFactory,
+        private StreamFactoryInterface $streamFactory,
+        private RequestFactoryInterface $requestFactory,
     ) {
     }
 

--- a/src/Auth/AccessTokenProvider/WithClientCredentials.php
+++ b/src/Auth/AccessTokenProvider/WithClientCredentials.php
@@ -10,14 +10,14 @@ use Vin\ShopwareSdk\Auth\GrantType;
 use Vin\ShopwareSdk\Auth\GrantType\ClientCredentialsGrantType;
 use Vin\ShopwareSdk\Data\AccessToken;
 
-final class WithClientCredentials implements AccessTokenProvider
+final readonly class WithClientCredentials implements AccessTokenProvider
 {
-    private readonly GrantType $grantType;
+    private GrantType $grantType;
 
     public function __construct(
         string $clientId,
         string $clientSecret,
-        private readonly AccessTokenFetcher $accessTokenFetcher
+        private AccessTokenFetcher $accessTokenFetcher
     ) {
         $this->grantType = new ClientCredentialsGrantType($clientId, $clientSecret);
     }

--- a/src/Auth/AccessTokenProvider/WithUsernameAndPassword.php
+++ b/src/Auth/AccessTokenProvider/WithUsernameAndPassword.php
@@ -10,14 +10,14 @@ use Vin\ShopwareSdk\Auth\GrantType;
 use Vin\ShopwareSdk\Auth\GrantType\PasswordGrantType;
 use Vin\ShopwareSdk\Data\AccessToken;
 
-final class WithUsernameAndPassword implements AccessTokenProvider
+final readonly class WithUsernameAndPassword implements AccessTokenProvider
 {
-    private readonly GrantType $grantType;
+    private GrantType $grantType;
 
     public function __construct(
         string $username,
         string $password,
-        private readonly AccessTokenFetcher $accessTokenFetcher,
+        private AccessTokenFetcher $accessTokenFetcher,
     ) {
         $this->grantType = new PasswordGrantType($username, $password);
     }

--- a/src/Context/ContextBuilderFactory.php
+++ b/src/Context/ContextBuilderFactory.php
@@ -6,11 +6,11 @@ namespace Vin\ShopwareSdk\Context;
 
 use Vin\ShopwareSdk\Auth\AccessTokenProvider;
 
-final class ContextBuilderFactory implements ContextBuilderFactoryInterface
+final readonly class ContextBuilderFactory implements ContextBuilderFactoryInterface
 {
     public function __construct(
-        private readonly string $shopUrl,
-        private readonly AccessTokenProvider $accessTokenProvider
+        private string $shopUrl,
+        private AccessTokenProvider $accessTokenProvider
     ) {
     }
 

--- a/src/Definition/DefinitionProvider.php
+++ b/src/Definition/DefinitionProvider.php
@@ -7,16 +7,16 @@ namespace Vin\ShopwareSdk\Definition;
 use Vin\ShopwareSdk\Data\Entity\EntityDefinition;
 use Vin\ShopwareSdk\Exception\DefinitionNotFoundException;
 
-final class DefinitionProvider implements DefinitionProviderInterface
+final readonly class DefinitionProvider implements DefinitionProviderInterface
 {
-    private readonly DefinitionCollection $definitionCollection;
+    private DefinitionCollection $definitionCollection;
 
     /**
      * @param iterable<DefinitionCollectionPopulator> $definitionCollectionPopulators
      */
     public function __construct(
-        private readonly iterable $definitionCollectionPopulators,
-        private readonly string $shopwareVersion
+        private iterable $definitionCollectionPopulators,
+        private string $shopwareVersion
     ) {
         $this->definitionCollection = new DefinitionCollection();
         foreach ($this->definitionCollectionPopulators as $definitionCollectionPopulator) {

--- a/src/Definition/SchemaProvider.php
+++ b/src/Definition/SchemaProvider.php
@@ -8,12 +8,12 @@ use Vin\ShopwareSdk\Data\Schema\Schema;
 use Vin\ShopwareSdk\Exception\DefinitionNotFoundException;
 use Vin\ShopwareSdk\Exception\SchemaNotFoundException;
 
-final class SchemaProvider implements SchemaProviderInterface
+final readonly class SchemaProvider implements SchemaProviderInterface
 {
-    private readonly SchemaCollection $schemaCollection;
+    private SchemaCollection $schemaCollection;
 
     public function __construct(
-        private readonly DefinitionProviderInterface $entityDefinitionProvider
+        private DefinitionProviderInterface $entityDefinitionProvider
     ) {
         $this->schemaCollection = new SchemaCollection();
     }

--- a/src/Http/HttpClient.php
+++ b/src/Http/HttpClient.php
@@ -11,12 +11,12 @@ use Vin\ShopwareSdk\Exception\ShopwareRequestException;
 use Vin\ShopwareSdk\Http\Struct\ApiResponse;
 use Vin\ShopwareSdk\Http\Struct\MediaType;
 
-final class HttpClient implements HttpClientInterface
+final readonly class HttpClient implements HttpClientInterface
 {
     public function __construct(
-        private readonly RequestFactoryInterface $requestFactory,
-        private readonly ResponseParserInterface $responseParser,
-        private readonly ClientInterface $psr18HttpClient,
+        private RequestFactoryInterface $requestFactory,
+        private ResponseParserInterface $responseParser,
+        private ClientInterface $psr18HttpClient,
     ) {
     }
 

--- a/src/Http/RequestFactory.php
+++ b/src/Http/RequestFactory.php
@@ -10,11 +10,11 @@ use Psr\Http\Message\StreamFactoryInterface;
 use Vin\ShopwareSdk\Data\Context;
 use Vin\ShopwareSdk\Http\Struct\MediaType;
 
-final class RequestFactory implements RequestFactoryInterface
+final readonly class RequestFactory implements RequestFactoryInterface
 {
     public function __construct(
-        private readonly StreamFactoryInterface $streamFactory,
-        private readonly PsrRequestFactoryInterface $requestFactory
+        private StreamFactoryInterface $streamFactory,
+        private PsrRequestFactoryInterface $requestFactory
     ) {
     }
 

--- a/src/Hydrate/Result/SearchResult.php
+++ b/src/Hydrate/Result/SearchResult.php
@@ -11,17 +11,17 @@ use Vin\ShopwareSdk\Hydrate\Service\AttributeHydratorInterface;
 use Vin\ShopwareSdk\Hydrate\Service\ExtensionParserInterface;
 use Vin\ShopwareSdk\Hydrate\Service\RelationshipsParserInterface;
 
-final class SearchResult
+final readonly class SearchResult
 {
-    private readonly EntityResultCache $entityResultCache;
+    private EntityResultCache $entityResultCache;
 
     /**
      * @param array{type: string, id: string, attributes: array<string, mixed>, relationships?: array<string, mixed>}[] $datasets
      * @param array{type: string, id: string, attributes: array<string, mixed>, relationships?: array<string, mixed>}[] $included
      */
     public function __construct(
-        private readonly array $datasets,
-        private readonly array $included,
+        private array $datasets,
+        private array $included,
     ) {
         $this->entityResultCache = new EntityResultCache();
     }

--- a/src/Hydrate/Service/AttributeHydrator.php
+++ b/src/Hydrate/Service/AttributeHydrator.php
@@ -7,10 +7,10 @@ namespace Vin\ShopwareSdk\Hydrate\Service;
 use Vin\ShopwareSdk\Data\Entity\Entity;
 use Vin\ShopwareSdk\Definition\SchemaProviderInterface;
 
-final class AttributeHydrator implements AttributeHydratorInterface
+final readonly class AttributeHydrator implements AttributeHydratorInterface
 {
     public function __construct(
-        private readonly SchemaProviderInterface $schemaProvider
+        private SchemaProviderInterface $schemaProvider
     ) {
     }
 

--- a/src/Repository/EntityRepository.php
+++ b/src/Repository/EntityRepository.php
@@ -22,13 +22,13 @@ use Vin\ShopwareSdk\Repository\Struct\IdSearchResult;
 use Vin\ShopwareSdk\Repository\Struct\SearchResultMeta;
 use Vin\ShopwareSdk\Repository\Struct\VersionResponse;
 
-final class EntityRepository implements RepositoryInterface
+final readonly class EntityRepository implements RepositoryInterface
 {
     public function __construct(
-        private readonly EntityDefinition $definition,
-        private readonly ContextBuilderFactoryInterface $contextBuilderFactory,
-        private readonly HttpClientInterface $httpClient,
-        private readonly HydratorInterface $hydrator,
+        private EntityDefinition $definition,
+        private ContextBuilderFactoryInterface $contextBuilderFactory,
+        private HttpClientInterface $httpClient,
+        private HydratorInterface $hydrator,
     ) {
     }
 

--- a/src/Service/AdminSearchService.php
+++ b/src/Service/AdminSearchService.php
@@ -13,13 +13,13 @@ use Vin\ShopwareSdk\Repository\Struct\EntitySearchResultCollection;
 use Vin\ShopwareSdk\Repository\Struct\SearchResultMeta;
 use Vin\ShopwareSdk\Service\Api\ApiServiceInterface;
 
-final class AdminSearchService implements AdminSearchServiceInterface
+final readonly class AdminSearchService implements AdminSearchServiceInterface
 {
     private const ADMIN_SEARCH_ENDPOINT = '/api/_admin/search';
 
     public function __construct(
-        private readonly ApiServiceInterface $apiService,
-        private readonly HydratorInterface $hydrator,
+        private ApiServiceInterface $apiService,
+        private HydratorInterface $hydrator,
     ) {
     }
 

--- a/src/Service/Api/ApiService.php
+++ b/src/Service/Api/ApiService.php
@@ -14,11 +14,11 @@ use Vin\ShopwareSdk\Http\Struct\ApiResponse;
 /**
  * @phpstan-import-type Headers from Context
  */
-final class ApiService implements ApiServiceInterface
+final readonly class ApiService implements ApiServiceInterface
 {
     public function __construct(
-        private readonly ContextBuilderFactoryInterface $contextBuilderFactory,
-        private readonly HttpClientInterface $httpClient,
+        private ContextBuilderFactoryInterface $contextBuilderFactory,
+        private HttpClientInterface $httpClient,
     ) {
     }
 

--- a/src/Service/DocumentService.php
+++ b/src/Service/DocumentService.php
@@ -8,7 +8,7 @@ use Vin\ShopwareSdk\Http\Struct\ApiResponse;
 use Vin\ShopwareSdk\Service\Api\ApiServiceInterface;
 use Vin\ShopwareSdk\Service\Struct\DocumentGenerateOperationCollection;
 
-final class DocumentService implements DocumentServiceInterface
+final readonly class DocumentService implements DocumentServiceInterface
 {
     private const CREATE_ENDPOINT = '/api/_action/order/document/%s/create';
 
@@ -19,7 +19,7 @@ final class DocumentService implements DocumentServiceInterface
     private const UPLOAD_ENDPOINT = '/api/_action/document/%s/upload';
 
     public function __construct(
-        private readonly ApiServiceInterface $apiService,
+        private ApiServiceInterface $apiService,
     ) {
     }
 

--- a/src/Service/MailSendService.php
+++ b/src/Service/MailSendService.php
@@ -8,14 +8,14 @@ use Vin\ShopwareSdk\Data\Mail\Mail;
 use Vin\ShopwareSdk\Service\Api\ApiServiceInterface;
 use Vin\ShopwareSdk\Http\Struct\ApiResponse;
 
-final class MailSendService implements MailSendServiceInterface
+final readonly class MailSendService implements MailSendServiceInterface
 {
     private const BUILD_PATH = '/api/_action/mail-template/build';
 
     private const SEND_PATH = '/api/_action/mail-template/send';
 
     public function __construct(
-        private readonly ApiServiceInterface $apiService,
+        private ApiServiceInterface $apiService,
     ) {
     }
 

--- a/src/Service/MediaService.php
+++ b/src/Service/MediaService.php
@@ -7,7 +7,7 @@ namespace Vin\ShopwareSdk\Service;
 use Vin\ShopwareSdk\Service\Api\ApiServiceInterface;
 use Vin\ShopwareSdk\Http\Struct\ApiResponse;
 
-final class MediaService implements MediaServiceInterface
+final readonly class MediaService implements MediaServiceInterface
 {
     private const PROVIDE_NAME_ENDPOINT = '/api/_action/media/provide-name';
 
@@ -16,7 +16,7 @@ final class MediaService implements MediaServiceInterface
     private const UPLOAD_ENDPOINT = '/api/_action/media/%s/upload';
 
     public function __construct(
-        private readonly ApiServiceInterface $apiService,
+        private ApiServiceInterface $apiService,
     ) {
     }
 

--- a/src/Service/NotificationService.php
+++ b/src/Service/NotificationService.php
@@ -9,14 +9,14 @@ use Vin\ShopwareSdk\Http\Struct\ApiResponse;
 use Vin\ShopwareSdk\Service\Struct\Notification;
 use Vin\ShopwareSdk\Service\Struct\NotificationCollection;
 
-final class NotificationService implements NotificationServiceInterface
+final readonly class NotificationService implements NotificationServiceInterface
 {
     private const NOTIFICATION_MESSAGE_ENDPOINT = '/api/notification/message';
 
     private const NOTIFICATION_ENDPOINT = '/api/notification';
 
     public function __construct(
-        private readonly ApiServiceInterface $apiService,
+        private ApiServiceInterface $apiService,
     ) {
     }
 

--- a/src/Service/NumberRangeService.php
+++ b/src/Service/NumberRangeService.php
@@ -7,10 +7,10 @@ namespace Vin\ShopwareSdk\Service;
 use Vin\ShopwareSdk\Service\Api\ApiServiceInterface;
 use Vin\ShopwareSdk\Http\Struct\ApiResponse;
 
-final class NumberRangeService implements NumberRangeServiceInterface
+final readonly class NumberRangeService implements NumberRangeServiceInterface
 {
     public function __construct(
-        private readonly ApiServiceInterface $apiService,
+        private ApiServiceInterface $apiService,
     ) {
     }
 

--- a/src/Service/StateMachineService.php
+++ b/src/Service/StateMachineService.php
@@ -7,10 +7,10 @@ namespace Vin\ShopwareSdk\Service;
 use Vin\ShopwareSdk\Service\Api\ApiServiceInterface;
 use Vin\ShopwareSdk\Http\Struct\ApiResponse;
 
-final class StateMachineService implements StateMachineServiceInterface
+final readonly class StateMachineService implements StateMachineServiceInterface
 {
     public function __construct(
-        private readonly ApiServiceInterface $apiService,
+        private ApiServiceInterface $apiService,
     ) {
     }
 

--- a/src/Service/SyncService.php
+++ b/src/Service/SyncService.php
@@ -8,12 +8,12 @@ use Vin\ShopwareSdk\Service\Api\ApiServiceInterface;
 use Vin\ShopwareSdk\Http\Struct\ApiResponse;
 use Vin\ShopwareSdk\Service\Struct\SyncPayload;
 
-final class SyncService implements SyncServiceInterface
+final readonly class SyncService implements SyncServiceInterface
 {
     private const SYNC_ENDPOINT = '/api/_action/sync';
 
     public function __construct(
-        private readonly ApiServiceInterface $apiService,
+        private ApiServiceInterface $apiService,
     ) {
     }
 

--- a/src/Service/SystemConfigService.php
+++ b/src/Service/SystemConfigService.php
@@ -9,7 +9,7 @@ use Vin\ShopwareSdk\Http\Struct\ApiResponse;
 use Vin\ShopwareSdk\Service\Struct\Config;
 use Vin\ShopwareSdk\Service\Struct\ConfigCollection;
 
-final class SystemConfigService implements SystemConfigServiceInterface
+final readonly class SystemConfigService implements SystemConfigServiceInterface
 {
     public const SYSTEM_CONFIG_CHECK_ENDPOINT = '/api/_action/system-config/check';
 
@@ -22,7 +22,7 @@ final class SystemConfigService implements SystemConfigServiceInterface
     public const SYSTEM_CONFIG_SAVE_BATCH_ENDPOINT = '/api/_action/system-config/batch';
 
     public function __construct(
-        private readonly ApiServiceInterface $apiService,
+        private ApiServiceInterface $apiService,
     ) {
     }
 

--- a/src/Service/UserConfigService.php
+++ b/src/Service/UserConfigService.php
@@ -9,12 +9,12 @@ use Vin\ShopwareSdk\Http\Struct\ApiResponse;
 use Vin\ShopwareSdk\Service\Struct\Config;
 use Vin\ShopwareSdk\Service\Struct\ConfigCollection;
 
-final class UserConfigService implements UserConfigServiceInterface
+final readonly class UserConfigService implements UserConfigServiceInterface
 {
     private const USER_CONFIG_ENDPOINT = '/api/_info/config-me';
 
     public function __construct(
-        private readonly ApiServiceInterface $apiService,
+        private ApiServiceInterface $apiService,
     ) {
     }
 

--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -8,7 +8,7 @@ use Vin\ShopwareSdk\Data\Entity\Entity;
 use Vin\ShopwareSdk\Definition\DefinitionProviderInterface;
 use Vin\ShopwareSdk\Service\Api\ApiServiceInterface;
 
-final class UserService implements UserServiceInterface
+final readonly class UserService implements UserServiceInterface
 {
     private const USER_ROLE_ENDPOINT = '/api/acl-role';
 
@@ -19,8 +19,8 @@ final class UserService implements UserServiceInterface
     private const USER_PING_ENDPOINT = '/api/_info/ping';
 
     public function __construct(
-        private readonly ApiServiceInterface $apiService,
-        private readonly DefinitionProviderInterface $definitionProvider,
+        private ApiServiceInterface $apiService,
+        private DefinitionProviderInterface $definitionProvider,
     ) {
     }
 

--- a/tests/Auth/AccessTokenProvider/MockAccessTokenProvider.php
+++ b/tests/Auth/AccessTokenProvider/MockAccessTokenProvider.php
@@ -7,10 +7,10 @@ namespace Vin\ShopwareSdkTest\Auth\AccessTokenProvider;
 use Vin\ShopwareSdk\Auth\AccessTokenProvider;
 use Vin\ShopwareSdk\Data\AccessToken;
 
-final class MockAccessTokenProvider implements AccessTokenProvider
+final readonly class MockAccessTokenProvider implements AccessTokenProvider
 {
     public function __construct(
-        private readonly AccessToken $accessToken
+        private AccessToken $accessToken
     ) {
     }
 


### PR DESCRIPTION
The active support for PHP 8.1 ended at the 25.11.2023.